### PR TITLE
Add Python protocol library

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -20,10 +20,22 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files(["VERSION"])
 load("@graknlabs_bazel_distribution//github:rules.bzl", "deploy_github")
+load("@stackb_rules_proto//python:python_grpc_library.bzl", "python_grpc_library")
 
 deploy_github(
     name = "deploy-github",
     deployment_properties = "//:deployment.properties",
     release_description = "//:RELEASE_TEMPLATE.md",
     version_file = "//:VERSION"
+)
+
+python_grpc_library(
+    name = "grakn_protocol",
+    deps = [
+        "//keyspace:keyspace-proto",
+        "//session:session-proto",
+        "//session:answer-proto",
+        "//session:concept-proto",
+    ],
+    visibility = ["//visibility:public"]
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -85,6 +85,26 @@ com_github_grpc_grpc_deps()
 load("@stackb_rules_proto//java:deps.bzl", "java_grpc_compile")
 java_grpc_compile()
 
+load("@stackb_rules_proto//python:deps.bzl", "python_grpc_library")
+python_grpc_library()
+
+pip_import(
+    name = "protobuf_py_deps",
+    requirements = "@stackb_rules_proto//python/requirements:protobuf.txt",
+)
+
+load("@protobuf_py_deps//:requirements.bzl", protobuf_pip_install = "pip_install")
+protobuf_pip_install()
+
+pip_import(
+    name = "grpc_py_deps",
+    requirements = "@stackb_rules_proto//python:requirements.txt",
+)
+
+load("@grpc_py_deps//:requirements.bzl", grpc_pip_install = "pip_install")
+grpc_pip_install()
+
+
 
 ##################################
 # Load Distribution dependencies #

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,5 +22,5 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "59cca36504bbe1dc4b5279c92fde9a8635720512", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "29aa0bd86256f84bcd05d113e0b5b40d876a4e53", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )


### PR DESCRIPTION
## What is the goal of this PR?

This PR makes `protocol` usable in `@graknlabs_client_python` by exposing `@graknlabs_protocol//:grakn_protocol` target.

## What are the changes implemented in this PR?

- Upgrade `@graknlabs_build_tools` to include graknlabs/build-tools#68
- Add `python_grpc_library` target which generates Python proto/grpc sources and exposes them as `py_library`
