### PR TITLE
Add NodeJS protocol library

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -21,6 +21,7 @@ package(default_visibility = ["//visibility:public"])
 exports_files(["VERSION"])
 load("@graknlabs_bazel_distribution//github:rules.bzl", "deploy_github")
 load("@stackb_rules_proto//python:python_grpc_compile.bzl", "python_grpc_compile")
+load("@stackb_rules_proto//node:node_grpc_compile.bzl", "node_grpc_compile")
 
 deploy_github(
     name = "deploy-github",
@@ -44,4 +45,14 @@ py_library(
     name = "grakn_protocol",
     srcs = ["grakn_protocol_src"],
     imports = ["grakn_protocol_src"]
+)
+
+node_grpc_compile(
+    name = "client-nodejs-proto",
+    deps = [
+        "//session:session-proto",
+        "//session:answer-proto",
+        "//session:concept-proto",
+        "//keyspace:keyspace-proto",
+    ]
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -85,6 +85,8 @@ com_github_grpc_grpc_deps()
 load("@stackb_rules_proto//java:deps.bzl", "java_grpc_compile")
 java_grpc_compile()
 
+load("@stackb_rules_proto//node:deps.bzl", "node_grpc_compile")
+node_grpc_compile()
 
 ##################################
 # Load Distribution dependencies #


### PR DESCRIPTION
## What is the goal of this PR?

This PR makes `protocol` usable in `@graknlabs_client_nodejs` by exposing `@graknlabs_protocol//:client-nodejs-proto` target.

## What are the changes implemented in this PR?

- Add `node_grpc_compile` target which generates Node proto/grpc sources
