### PR TITLE
Prefixed artifact IDs of Maven packages with 'grakn-'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,8 +65,7 @@ jobs:
           bazel run @graknlabs_build_tools//ci:sync-dependencies -- \
           --source protocol@$CIRCLE_SHA1 \
           --targets \
-          grakn:master client-java:master client-python:master
-        # TODO: Add client-nodejs:master
+          grakn:master client-java:master client-python:master client-nodejs:master
 
   release-approval:
     machine: true

--- a/keyspace/BUILD
+++ b/keyspace/BUILD
@@ -43,7 +43,7 @@ java_library(
         "//dependencies/maven/artifacts/io/grpc:grpc-protobuf",
         "//dependencies/maven/artifacts/io/grpc:grpc-stub",
     ],
-    tags = ["maven_coordinates=io.grakn.protocol:keyspace:{pom_version}", "checkstyle_ignore"],
+    tags = ["maven_coordinates=io.grakn.protocol:grakn-keyspace:{pom_version}", "checkstyle_ignore"],
 )
 
 assemble_maven(

--- a/session/BUILD
+++ b/session/BUILD
@@ -57,7 +57,7 @@ java_library(
         "//dependencies/maven/artifacts/io/grpc:grpc-protobuf",
         "//dependencies/maven/artifacts/io/grpc:grpc-stub",
     ],
-    tags = ["maven_coordinates=io.grakn.protocol:session:{pom_version}", "checkstyle_ignore"],
+    tags = ["maven_coordinates=io.grakn.protocol:grakn-session:{pom_version}", "checkstyle_ignore"],
 )
 
 assemble_maven(


### PR DESCRIPTION
## What is the goal of this PR?

When deploying Maven JARs to Sonatype, the JARs are renamed to be `artifact-id-version.jar`, without the `group-id`. This is done in Sonatype because the JARs are organised into folders where the folder names represent the Group IDs. However, in certain build systems, e.g. Gradle, the JARs are collected under one directory, which means the JAR names are not unique enough to disambiguate itself from each other. We have now renamed the artifact ID of our Maven packages to be prefixed with `grakn-` to solve this problem.

## What are the changes implemented in this PR?

Prefixed artifact IDs of Maven packages with 'grakn-' (fixes https://github.com/graknlabs/grakn/issues/5127, fixes https://github.com/graknlabs/bazel-distribution/issues/112).