### PR TITLE
Move generated Python code under grakn_protocol package

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -18,7 +18,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-exports_files(["VERSION"])
+exports_files(["VERSION", "python_proto.py"])
 load("@graknlabs_bazel_distribution//github:rules.bzl", "deploy_github")
 
 deploy_github(
@@ -26,4 +26,28 @@ deploy_github(
     deployment_properties = "//:deployment.properties",
     release_description = "//:RELEASE_TEMPLATE.md",
     version_file = "//:VERSION"
+)
+
+genrule(
+    name = "python-package-structure",
+    srcs = [
+        "//keyspace:Keyspace.proto",
+        "//session:Session.proto",
+        "//session:Concept.proto",
+        "//session:Answer.proto",
+    ],
+    cmd = "$(location :python_proto.py) --pkg grakn_protocol --srcs $(SRCS) --outs $(OUTS)",
+    outs = [
+        "grakn_protocol/keyspace/Keyspace.proto",
+        "grakn_protocol/session/Session.proto",
+        "grakn_protocol/session/Concept.proto",
+        "grakn_protocol/session/Answer.proto",
+    ],
+    tools = [":python_proto.py"]
+)
+
+
+proto_library(
+    name = "python-protos",
+    srcs = [":python-package-structure"],
 )

--- a/grpc/python/BUILD
+++ b/grpc/python/BUILD
@@ -22,10 +22,7 @@ load("@stackb_rules_proto//python:python_grpc_compile.bzl", "python_grpc_compile
 python_grpc_compile(
     name = "protocol_src",
     deps = [
-        "//keyspace:keyspace-proto",
-        "//session:session-proto",
-        "//session:answer-proto",
-        "//session:concept-proto",
+        "//:python-protos",
     ],
     visibility = ["//visibility:public"]
 )
@@ -33,5 +30,5 @@ python_grpc_compile(
 py_library(
     name = "protocol",
     srcs = ["protocol_src"],
-    imports = ["protocol_src"]
+    imports = ["../../"]
 )

--- a/python_proto.py
+++ b/python_proto.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+import argparse
+
+import sys
+import re
+
+IMPORT_PATTERN = re.compile(r'import "(?P<imported>.*)";\n')
+
+print(sys.argv)
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--pkg', help="Proto sources to preprocess")
+parser.add_argument('--srcs', nargs='+', help="Proto sources to preprocess")
+parser.add_argument('--outs', nargs='+', help="Outputs")
+
+args = parser.parse_args()
+print(args)
+
+for src, out in zip(args.srcs, args.outs):
+    with open(src) as srcf:
+        lines = srcf.readlines()
+    for i, line in enumerate(lines):
+        m = IMPORT_PATTERN.match(line)
+        if m:
+            new_import = "/".join([
+                args.pkg.replace('.', '/'),
+                m.group('imported')
+            ])
+            lines[i] = 'import "{}";\n'.format(new_import)
+    with open(out, 'w') as outf:
+        outf.writelines(lines)


### PR DESCRIPTION
## What is the goal of this PR?

Previously, generated Python package contained `keyspace` and `session` packages — which have pretty generic names to be put into user's directory with installed Python packages. This PR moves them under `grakn_protocol` root package.

## What are the changes implemented in this PR?

- Add `python_proto.py` tool which rewires imports in `.proto` files according to new structure
- Add `python-package-structure` which preprocesses `.proto` files so they have structure we want in generated Python code
- Replace `imports` in `py_library` so that correct folder is imported (will be needed after `@stackb_rules_proto` is upgraded to latest `master`)