### PR TITLE
Repackage Python generated code

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -63,6 +63,15 @@ graknlabs_build_tools_ci_pip_install = "pip_install")
 graknlabs_build_tools_ci_pip_install()
 
 
+pip_import(
+    name = "graknlabs_bazel_distribution_pip",
+    requirements = "@graknlabs_bazel_distribution//pip:requirements.txt",
+)
+load("@graknlabs_bazel_distribution_pip//:requirements.bzl",
+graknlabs_bazel_distribution_pip_install = "pip_install")
+graknlabs_bazel_distribution_pip_install()
+
+
 #####################################
 # Load Java dependencies from Maven #
 #####################################

--- a/grpc/python/BUILD
+++ b/grpc/python/BUILD
@@ -18,6 +18,7 @@
 
 package(default_visibility = ["//visibility:public"])
 load("@stackb_rules_proto//python:python_grpc_compile.bzl", "python_grpc_compile")
+load("@graknlabs_bazel_distribution//pip:rules.bzl", "python_repackage")
 
 python_grpc_compile(
     name = "protocol_src",
@@ -30,8 +31,16 @@ python_grpc_compile(
     visibility = ["//visibility:public"]
 )
 
+
+python_repackage(
+    name = "protocol_pkg",
+    src = ":protocol_src",
+    package = "grakn_protocol"
+)
+
+
 py_library(
     name = "protocol",
-    srcs = ["protocol_src"],
-    imports = ["protocol_src"]
+    srcs = ["protocol_pkg"],
+    imports = ["../../grpc/python"]
 )


### PR DESCRIPTION
## What is the goal of this PR?

Previously, generated Python package contained `keyspace` and `session` packages — which have pretty generic names to be put into user's directory with installed Python packages. This PR moves them under `grakn_protocol` root package.

## What are the changes implemented in this PR?

- Introduced `python_repackage` target which rewires imports in Python generated files
- Replace `imports` in `py_library` so that correct folder is imported
