### PR TITLE
Authenticate operations in KeyspaceService

### DIFF
--- a/keyspace/Keyspace.proto
+++ b/keyspace/Keyspace.proto
@@ -24,29 +24,28 @@ option java_outer_classname = "KeyspaceProto";
 package keyspace;
 
 service KeyspaceService {
-    rpc create (Keyspace.Create.Req) returns (Keyspace.Create.Res);
     rpc retrieve (Keyspace.Retrieve.Req) returns (Keyspace.Retrieve.Res);
     rpc delete (Keyspace.Delete.Req) returns (Keyspace.Delete.Res);
 }
 
 message Keyspace {
     message Retrieve {
-        message Req {}
+        message Req {
+            /* Fields ignored in the open-source version. */
+            string username = 1;
+            string password = 2;
+        }
         message Res {
             repeated string names = 1;
         }
     }
 
-    message Create {
-        message Req {
-            string name = 1;
-        }
-        message Res {}
-    }
-
     message Delete {
         message Req {
             string name = 1;
+            /* Fields ignored in the open-source version. */
+            string username = 2;
+            string password = 3;
         }
         message Res {}
     }


### PR DESCRIPTION
## What is the goal of this PR?

Operations with keyspaces need to be authenticated with `username`/`password` in enterprise version. In order to support that, protocol needs to be changed. Additionally, RPC method to create keyspace is now obsolete and needs to be removed.

## What are the changes implemented in this PR?

* Remove `create` RPC method as well as `Create.Req`/`Create.Res`
* Accept `username` and `password` in `Retrieve.Req` and `Delete.Req`
