### PR TITLE
Update RELEASE_TEMPLATE.md

### DIFF
--- a/RELEASE_TEMPLATE.md
+++ b/RELEASE_TEMPLATE.md
@@ -26,26 +26,4 @@ Available through https://repo.grakn.ai
 </dependencies>
 ```
 
-#### For Python through PyPI
-
-Available through https://pypi.org
-```
-pip install grakn-protocol
-```
-Or you can upgrade your local installation with:
-```
-pip install -U grakn-protocol
-```
-
-#### For Node.js through NPM
-
-Now officially available through https://npmjs.com
-```
-npm install grakn-protocol
-```
-Or you can upgrade your local installation with:
-```
-npm update grakn-protocol
-```
-
 { release notes }


### PR DESCRIPTION
## What is the goal of this PR?

We have removed NodeJS and PyPI installation instruction since `protocol` is a Maven artifact.
