### PR TITLE
Add title to GitHub Release

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -25,5 +25,7 @@ deploy_github(
     name = "deploy-github",
     deployment_properties = "//:deployment.properties",
     release_description = "//:RELEASE_TEMPLATE.md",
+    title = "Protocol",
+    title_append_version = True,
     version_file = "//:VERSION"
 )


### PR DESCRIPTION
## What is the goal of this PR?

Make GitHub releases less prone to error

## What are the changes implemented in this PR?

Supply attributes to `deploy_github` such that title is filled automatically during a release
