### PR TITLE
Use Github credential for release-cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ jobs:
     working_directory: ~/protocol
     steps:
       - checkout
-      - run: git push --delete origin protocol-release-branch
+      - run: git push --delete https://$REPO_GITHUB_TOKEN@github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME $CIRCLE_BRANCH
 
 workflows:
   protocol:


### PR DESCRIPTION
## What is the goal of this PR?

Use GitHub credential for release-cleanup. This removes the need for adding an additional SSH key to CircleCI.