### PR TITLE
Adapt to latest changes in bazel-distribution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
       - run: |
           export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
           export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
-          bazel run //grpc/java:deploy-maven -- snapshot $CIRCLE_SHA1
+          bazel run --define version=$(git rev-parse HEAD) //grpc/java:deploy-maven -- snapshot
 
   sync-dependencies-snapshot:
     machine: true
@@ -101,7 +101,7 @@ jobs:
       - run: |
           export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
           export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
-          bazel run //grpc/java:deploy-maven -- release $(cat VERSION)
+          bazel run --define version=$(cat VERSION) //grpc/java:deploy-maven -- release
 
   sync-dependencies-release:
     machine: true

--- a/grpc/java/BUILD
+++ b/grpc/java/BUILD
@@ -47,7 +47,6 @@ assemble_maven(
     name = "assemble-maven",
     target = ":protocol",
     package = "grpc",
-    version_file = "//:VERSION",
     workspace_refs = "@graknlabs_protocol_workspace_refs//:refs.json"
 )
 


### PR DESCRIPTION
## What is the goal of this PR?

graknlabs/bazel-distribution#191 changed the way Maven JARs are built. This PR adapts `protocol` to latest changes

## What are the changes implemented in this PR?

* Use `--define` to supply version to Maven deployment rule
* Remove `version_file` from `assemble_maven` arguments
