### PR TITLE
Refactor how version is provided to deployment rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
           bazel run @graknlabs_build_tools//ci:release-notes -- protocol $(cat VERSION) ./RELEASE_TEMPLATE.md
       - run: |
           export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
-          bazel run //:deploy-github -- $CIRCLE_SHA1
+          bazel run --define version=$(cat VERSION) //:deploy-github -- $CIRCLE_SHA1
 
   deploy-maven:
     machine: true

--- a/BUILD
+++ b/BUILD
@@ -27,5 +27,4 @@ deploy_github(
     release_description = "//:RELEASE_TEMPLATE.md",
     title = "Protocol",
     title_append_version = True,
-    version_file = "//:VERSION"
 )


### PR DESCRIPTION
## What is the goal of this PR?

Adapt `@graknlabs_protocol` to latest changes in bazel-distribution (in particular, graknlabs/bazel-distribution#150)

## What are the changes implemented in this PR?

Instead of supplying `version_file` everywhere, use `--define version=<>` as a Bazel argument to supply version.

