### PR TITLE
Add Void Answer Message type

### DIFF
--- a/session/Answer.proto
+++ b/session/Answer.proto
@@ -33,7 +33,7 @@ message Answer {
         ConceptSet conceptSet = 4;
         ConceptSetMeasure conceptSetMeasure = 5;
         Value value = 6;
-        ConceptSingle conceptId = 7;
+        Void void = 7;
     }
 }
 
@@ -74,8 +74,8 @@ message Value {
     Explanation explanation = 2;
 }
 
-message ConceptSingle {
-    string conceptId = 1;
+message Void {
+    string message = 1;
 }
 
 message ConceptIds {

--- a/session/Answer.proto
+++ b/session/Answer.proto
@@ -33,6 +33,7 @@ message Answer {
         ConceptSet conceptSet = 4;
         ConceptSetMeasure conceptSetMeasure = 5;
         Value value = 6;
+        ConceptSingle conceptId = 7;
     }
 }
 
@@ -71,6 +72,10 @@ message ConceptSetMeasure {
 message Value {
     Number number = 1;
     Explanation explanation = 2;
+}
+
+message ConceptSingle {
+    string conceptId = 1;
 }
 
 message ConceptIds {


### PR DESCRIPTION
## What is the goal of this PR?
With the end goal of streaming deleted concept IDs, we add a backwards-compatible message type `ConceptSingle` that contains a single concept ID. This means deleted concept IDs can now be streamed rather than be returned in one batch as a `ConceptSet`

Related to https://github.com/graknlabs/grakn/issues/4969

## What are the changes implemented in this PR?
* Add a backwards compatible extension to `Answer` message type in `Answer.proto` that can be streamed after a delete