### PR TITLE
Integrate checking for unused Java dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ jobs:
       - install-bazel-linux-rbe
       - run-bazel-rbe:
           command: bazel build //...
+      - run: bazel run @graknlabs_build_tools//unused_deps -- list
 
   deploy-maven-snapshot:
     machine: true

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,6 +29,8 @@ graknlabs_build_tools()
 load("@graknlabs_build_tools//distribution:dependencies.bzl", "graknlabs_bazel_distribution")
 graknlabs_bazel_distribution()
 
+load("@graknlabs_build_tools//unused_deps:dependencies.bzl", "unused_deps_dependencies")
+unused_deps_dependencies()
 
 ###########################
 # Load Bazel dependencies #


### PR DESCRIPTION
## What is the goal of this PR?

Integrate checking for unused Java dependencies

## What are the changes implemented in this PR?

- Load `@graknlabs_build_tools//unused_deps`'s dependencies
- Check for unused dependencies in `build` CI job
