### PR TITLE
Retrievable explanations, Restrict explanations to ConceptMaps

### DIFF
--- a/session/Answer.proto
+++ b/session/Answer.proto
@@ -37,22 +37,12 @@ message Answer {
     }
 }
 
-message Cause {
-    string pattern = 1;
-}
-
 message Explanation {
     message Req {
-        ConceptMap answer = 1;
+        ConceptMap explainable = 1;
     }
     message Res {
-        int32 iter_id = 1;
-        ConceptMap conceptMap = 2;
-    }
-    message Iter {
-        message Res {
-            ConceptMap conceptMap = 1;
-        }
+        repeated ConceptMap explanation = 1;
     }
 }
 
@@ -63,7 +53,8 @@ message AnswerGroup {
 
 message ConceptMap {
     map<string, Concept> map = 1;
-    Cause cause = 2;
+    string pattern = 2;
+    bool hasExplanation = 3;
 }
 
 message ConceptList {

--- a/session/Answer.proto
+++ b/session/Answer.proto
@@ -37,41 +37,46 @@ message Answer {
     }
 }
 
-message Explanation {
+message Cause {
     string pattern = 1;
-    repeated ConceptMap answers = 2;
+}
+
+message Explanation {
+    message Req {
+        ConceptMap answer;
+    }
+    message Iter {
+        message Res {
+            ConceptMap conceptMap = 1;
+        }
+    }
 }
 
 message AnswerGroup {
     Concept owner = 1;
     repeated Answer answers = 2;
-    Explanation explanation = 3;
 }
 
 message ConceptMap {
     map<string, Concept> map = 1;
-    Explanation explanation = 2;
+    Cause cause = 2;
 }
 
 message ConceptList {
     ConceptIds list = 1;
-    Explanation explanation = 2;
 }
 
 message ConceptSet {
     ConceptIds set = 1;
-    Explanation explanation = 2;
 }
 
 message ConceptSetMeasure {
     ConceptIds set = 1;
     Number measurement = 2;
-    Explanation explanation = 3;
 }
 
 message Value {
     Number number = 1;
-    Explanation explanation = 2;
 }
 
 message Void {

--- a/session/Answer.proto
+++ b/session/Answer.proto
@@ -43,7 +43,11 @@ message Cause {
 
 message Explanation {
     message Req {
-        ConceptMap answer;
+        ConceptMap answer = 1;
+    }
+    message Res {
+        int32 iter_id = 1;
+        ConceptMap conceptMap = 2;
     }
     message Iter {
         message Res {

--- a/session/Session.proto
+++ b/session/Session.proto
@@ -76,6 +76,7 @@ message Transaction {
             PutRole.Req putRole_req = 11;
             PutRule.Req putRule_req = 12;
             ConceptMethod.Req conceptMethod_req = 13;
+            Explanation.Req explanation_req = 14;
         }
     }
     message Res {
@@ -93,6 +94,7 @@ message Transaction {
             PutRole.Res putRole_res = 11;
             PutRule.Res putRule_res = 12;
             ConceptMethod.Res conceptMethod_res = 13;
+            Explanation.Res explanation_res = 14;
         }
     }
 
@@ -242,13 +244,6 @@ message Transaction {
         }
         message Res {
             Method.Res response = 1;
-        }
-    }
-
-    message ExplanationMethod {
-        message Req {
-            string id = 1;
-            Explanation.Req = 2;
         }
     }
 }

--- a/session/Session.proto
+++ b/session/Session.proto
@@ -106,6 +106,7 @@ message Transaction {
                 Query.Iter.Res query_iter_res = 2;
                 GetAttributes.Iter.Res getAttributes_iter_res = 3;
                 Method.Iter.Res conceptMethod_iter_res = 4;
+                Explanation.Iter.Res explanation_iter_res = 5;
             }
         }
     }
@@ -241,6 +242,13 @@ message Transaction {
         }
         message Res {
             Method.Res response = 1;
+        }
+    }
+
+    message ExplanationMethod {
+        message Req {
+            string id = 1;
+            Explanation.Req = 2;
         }
     }
 }

--- a/session/Session.proto
+++ b/session/Session.proto
@@ -108,7 +108,6 @@ message Transaction {
                 Query.Iter.Res query_iter_res = 2;
                 GetAttributes.Iter.Res getAttributes_iter_res = 3;
                 Method.Iter.Res conceptMethod_iter_res = 4;
-                Explanation.Iter.Res explanation_iter_res = 5;
             }
         }
     }


### PR DESCRIPTION
## What is the goal of this PR?
Explanations can exceed the gRPC message size limits. This change allows retrieving explanations separately from the `ConceptMap` answers themselves, allowing us to break the deep nesting and long messages contained in a single answer. 

The paradigm for retriving an explanation is now as follows:
A `ConceptMap` always contains a `pattern` and a boolean flag `hasExplanation`. If the `ConceptMap` has an explanation, a call can be made using message type `Explanation.Req`, returning a list of `ConceptMap` that correspond to to a single layer of the explanation tree.

Unused `Explanation` messages have been removed from answers other than `ConceptMap`.

## What are the changes implemented in this PR?
* `ConceptMap` contains `conceptMap`, `pattern` and `hasExplanation`
* A new RPC endpoint can be performed by clients using type `Explanation.Req`, returning `Explanation.Res`
* `Explanation` removed from answers other than `ConceptMap`
