### PR TITLE
Add a rule to explanation results

### DIFF
--- a/session/Answer.proto
+++ b/session/Answer.proto
@@ -42,6 +42,7 @@ message Explanation {
     }
     message Res {
         repeated ConceptMap explanation = 1;
+        Concept rule = 2;
     }
 }
 


### PR DESCRIPTION
## What is the goal of this PR?

When the client requests an explanation for a query, we want to also return the rule that is being explained. Therefore, we add the ability to pass a rule inside an explanation.

Required by:
[https://github.com/graknlabs/client-java/pull/81](https://github.com/graknlabs/client-java/pull/81)
[https://github.com/graknlabs/grakn/pull/5657](https://github.com/graknlabs/grakn/pull/5657)
## What are the changes implemented in this PR?

- Add a rule as a `Concept` within an explanation response.