### PR TITLE
Add prefilling of various response methods

### DIFF
--- a/session/Concept.proto
+++ b/session/Concept.proto
@@ -107,24 +107,14 @@ message Method {
             SchemaConcept.SetLabel.Res schemaConcept_setLabel_res = 202;
             SchemaConcept.GetSup.Res schemaConcept_getSup_res = 203;
             SchemaConcept.SetSup.Res schemaConcept_setSup_res = 204;
-            SchemaConcept.Sups.Iter schemaConcept_sups_iter = 205;
-            SchemaConcept.Subs.Iter schemaConcept_subs_iter = 206;
 
             // Rule method responses
             Rule.When.Res rule_when_res = 300;
             Rule.Then.Res rule_then_res = 301;
 
-            // Role method responses
-            Role.Relations.Iter role_relations_iter = 401;
-            Role.Players.Iter role_players_iter = 402;
-
             // Type method responses
             Type.IsAbstract.Res type_isAbstract_res = 500;
             Type.SetAbstract.Res type_setAbstract_res = 501;
-            Type.Instances.Iter type_instances_iter = 502;
-            Type.Keys.Iter type_keys_iter = 503;
-            Type.Attributes.Iter type_attributes_iter = 504;
-            Type.Playing.Iter type_playing_iter = 505;
             Type.Has.Res type_has_res = 506;
             Type.Key.Res type_key_res = 507;
             Type.Plays.Res type_plays_res = 508;
@@ -137,7 +127,6 @@ message Method {
 
             // RelationType method responses
             RelationType.Create.Res relationType_create_res = 700;
-            RelationType.Roles.Iter relationType_roles_iter = 701;
             RelationType.Relates.Res relationType_relates_res = 702;
             RelationType.Unrelate.Res relationType_unrelate_res = 703;
 
@@ -151,22 +140,15 @@ message Method {
             // Thing method responses
             Thing.Type.Res thing_type_res = 900;
             Thing.IsInferred.Res thing_isInferred_res = 901;
-            Thing.Keys.Iter thing_keys_iter = 902;
-            Thing.Attributes.Iter thing_attributes_iter = 903;
-            Thing.Relations.Iter thing_relations_iter = 904;
-            Thing.Roles.Iter thing_roles_iter = 905;
             Thing.Relhas.Res thing_relhas_res = 906;
             Thing.Unhas.Res thing_unhas_res = 907;
 
             // Relation method responses
-            Relation.RolePlayersMap.Iter relation_rolePlayersMap_iter = 1000;
-            Relation.RolePlayers.Iter relation_rolePlayers_iter = 1001;
             Relation.Assign.Res relation_assign_res = 1002;
             Relation.Unassign.Res relation_unassign_res = 1003;
 
             // Attribute method responses
             Attribute.Value.Res attribute_value_res = 1100;
-            Attribute.Owners.Iter attribute_owners_iter = 1101;
         }
     }
 

--- a/session/Concept.proto
+++ b/session/Concept.proto
@@ -593,7 +593,6 @@ message Thing {
             repeated Concept attributeTypes = 1;
         }
         message Iter {
-            int32 id = 1;
             message Res {
                 Concept attribute = 1;
             }
@@ -645,8 +644,6 @@ message Relation {
     message RolePlayersMap {
         message Req {}
         message Iter {
-            int32 id = 1;
-
             message Res {
                 Concept role = 1;
                 Concept player = 2;

--- a/session/Concept.proto
+++ b/session/Concept.proto
@@ -213,8 +213,6 @@ message Concept {
     string id = 1;
     BASE_TYPE baseType = 2;
 
-    bool isPrefilled = 3;
-
     // Pre-filled responses:
     Thing.Type.Res type_res = 5;
     Thing.IsInferred.Res inferred_res = 6;

--- a/session/Concept.proto
+++ b/session/Concept.proto
@@ -213,6 +213,16 @@ message Concept {
     string id = 1;
     BASE_TYPE baseType = 2;
 
+    bool isPrefilled = 3;
+
+    // Pre-filled responses:
+    Thing.Type.Res type_res = 5;
+    Thing.IsInferred.Res inferred_res = 6;
+    Attribute.Value.Res value_res = 7;
+    AttributeType.DataType.Res dataType_res = 8;
+    SchemaConcept.GetLabel.Res label_res = 9;
+    SchemaConcept.IsImplicit.Res isImplicit_res = 10;
+
     enum BASE_TYPE {
         META_TYPE = 0;
         ENTITY_TYPE = 1;

--- a/session/Concept.proto
+++ b/session/Concept.proto
@@ -282,9 +282,10 @@ message SchemaConcept {
     }
     
     message Sups {
-        message Req {}
+        message Req {
+            int32 iter_id = 1;
+        }
         message Iter {
-            int32 id = 1;
             message Res {
                 Concept schemaConcept = 1;
             }
@@ -292,9 +293,10 @@ message SchemaConcept {
     }
     
     message Subs {
-        message Req {}
+        message Req {
+            int32 iter_id = 1;
+        }
         message Iter {
-            int32 id = 1;
             message Res {
                 Concept schemaConcept = 1;
             }
@@ -334,9 +336,10 @@ message Rule {
 message Role {
 
     message Relations {
-        message Req {}
+        message Req {
+            int32 iter_id = 1;
+        }
         message Iter {
-            int32 id = 1;
             message Res {
                 Concept relationType = 1;
             }
@@ -344,9 +347,10 @@ message Role {
     }
 
     message Players {
-        message Req {}
+        message Req {
+            int32 iter_id = 1;
+        }
         message Iter {
-            int32 id = 1;
             message Res {
                 Concept type = 1;
             }
@@ -374,9 +378,10 @@ message Type {
     }
 
     message Instances {
-        message Req {}
+        message Req {
+            int32 iter_id = 1;
+        }
         message Iter {
-            int32 id = 1;
             message Res {
                 Concept thing = 1;
             }
@@ -384,9 +389,10 @@ message Type {
     }
 
     message Attributes {
-        message Req {}
+        message Req {
+            int32 iter_id = 1;
+        }
         message Iter {
-            int32 id = 1;
             message Res {
                 Concept attributeType = 1;
             }
@@ -394,9 +400,10 @@ message Type {
     }
 
     message Keys {
-        message Req {}
+        message Req {
+            int32 iter_id = 1;
+        }
         message Iter {
-            int32 id = 1;
             message Res {
                 Concept attributeType = 1;
             }
@@ -404,9 +411,10 @@ message Type {
     }
 
     message Playing {
-        message Req {}
+        message Req {
+            int32 iter_id = 1;
+        }
         message Iter {
-            int32 id = 1;
             message Res {
                 Concept role = 1;
             }
@@ -482,9 +490,10 @@ message RelationType {
     }
 
     message Roles {
-        message Req {}
+        message Req {
+            int32 iter_id = 1;
+        }
         message Iter {
-            int32 id = 1;
             message Res {
                 Concept role = 1;
             }
@@ -589,9 +598,9 @@ message Thing {
     message Keys {
         message Req {
             repeated Concept attributeTypes = 1;
+            int32 iter_id = 2;
         }
         message Iter {
-            int32 id = 1;
             message Res {
                 Concept attribute = 1;
             }
@@ -613,9 +622,9 @@ message Thing {
     message Relations {
         message Req {
             repeated Concept roles = 1;
+            int32 iter_id = 2;
         }
         message Iter {
-            int32 id = 1;
             message Res {
                 Concept relation = 1;
             }
@@ -623,9 +632,10 @@ message Thing {
     }
 
     message Roles {
-        message Req {}
+        message Req {
+            int32 iter_id = 1;
+        }
         message Iter {
-            int32 id = 1;
             message Res {
                 Concept role = 1;
             }
@@ -658,6 +668,8 @@ message Relation {
         message Req {}
         message Iter {
             int32 id = 1;
+            int32 iter_id = 2;
+
             message Res {
                 Concept role = 1;
                 Concept player = 2;
@@ -668,9 +680,9 @@ message Relation {
     message RolePlayers {
         message Req {
             repeated Concept roles = 1;
+            int32 iter_id = 2;
         }
         message Iter {
-            int32 id = 1;
             message Res {
                 Concept thing = 1;
             }
@@ -706,9 +718,10 @@ message Attribute {
     }
 
     message Owners {
-        message Req {}
+        message Req {
+            int32 iter_id = 1;
+        }
         message Iter {
-            int32 id = 1;
             message Res {
                 Concept thing = 1;
             }

--- a/session/Concept.proto
+++ b/session/Concept.proto
@@ -282,9 +282,7 @@ message SchemaConcept {
     }
     
     message Sups {
-        message Req {
-            int32 iter_id = 1;
-        }
+        message Req {}
         message Iter {
             message Res {
                 Concept schemaConcept = 1;
@@ -293,9 +291,7 @@ message SchemaConcept {
     }
     
     message Subs {
-        message Req {
-            int32 iter_id = 1;
-        }
+        message Req {}
         message Iter {
             message Res {
                 Concept schemaConcept = 1;
@@ -336,9 +332,7 @@ message Rule {
 message Role {
 
     message Relations {
-        message Req {
-            int32 iter_id = 1;
-        }
+        message Req {}
         message Iter {
             message Res {
                 Concept relationType = 1;
@@ -347,9 +341,7 @@ message Role {
     }
 
     message Players {
-        message Req {
-            int32 iter_id = 1;
-        }
+        message Req {}
         message Iter {
             message Res {
                 Concept type = 1;
@@ -378,9 +370,7 @@ message Type {
     }
 
     message Instances {
-        message Req {
-            int32 iter_id = 1;
-        }
+        message Req {}
         message Iter {
             message Res {
                 Concept thing = 1;
@@ -389,9 +379,7 @@ message Type {
     }
 
     message Attributes {
-        message Req {
-            int32 iter_id = 1;
-        }
+        message Req {}
         message Iter {
             message Res {
                 Concept attributeType = 1;
@@ -400,9 +388,7 @@ message Type {
     }
 
     message Keys {
-        message Req {
-            int32 iter_id = 1;
-        }
+        message Req {}
         message Iter {
             message Res {
                 Concept attributeType = 1;
@@ -411,9 +397,7 @@ message Type {
     }
 
     message Playing {
-        message Req {
-            int32 iter_id = 1;
-        }
+        message Req {}
         message Iter {
             message Res {
                 Concept role = 1;
@@ -490,9 +474,7 @@ message RelationType {
     }
 
     message Roles {
-        message Req {
-            int32 iter_id = 1;
-        }
+        message Req {}
         message Iter {
             message Res {
                 Concept role = 1;
@@ -598,7 +580,6 @@ message Thing {
     message Keys {
         message Req {
             repeated Concept attributeTypes = 1;
-            int32 iter_id = 2;
         }
         message Iter {
             message Res {
@@ -622,7 +603,6 @@ message Thing {
     message Relations {
         message Req {
             repeated Concept roles = 1;
-            int32 iter_id = 2;
         }
         message Iter {
             message Res {
@@ -632,9 +612,7 @@ message Thing {
     }
 
     message Roles {
-        message Req {
-            int32 iter_id = 1;
-        }
+        message Req {}
         message Iter {
             message Res {
                 Concept role = 1;
@@ -668,7 +646,6 @@ message Relation {
         message Req {}
         message Iter {
             int32 id = 1;
-            int32 iter_id = 2;
 
             message Res {
                 Concept role = 1;
@@ -680,7 +657,6 @@ message Relation {
     message RolePlayers {
         message Req {
             repeated Concept roles = 1;
-            int32 iter_id = 2;
         }
         message Iter {
             message Res {
@@ -718,9 +694,7 @@ message Attribute {
     }
 
     message Owners {
-        message Req {
-            int32 iter_id = 1;
-        }
+        message Req {}
         message Iter {
             message Res {
                 Concept thing = 1;

--- a/session/Session.proto
+++ b/session/Session.proto
@@ -100,7 +100,10 @@ message Transaction {
     message Iter {
         message Req {
             int32 id = 1;
-            bool all = 2;
+            oneof stream_mode {
+                bool all = 2;
+                int32 batch = 3;
+            }
         }
         message Res {
             oneof res {
@@ -138,9 +141,11 @@ message Transaction {
             INFER infer = 2;
             // We cannot use bool for `infer` because GRPC's default value for bool is FALSE
             // We use enum INFER instead, because the default value is index 0 (TRUE)
+
+            int32 id = 3;
+            // Optionally specify iterator id. If not 0, server will not respond and will use this id.
         }
         message Iter {
-            int32 id = 1;
             message Res {
                 Answer answer = 1;
             }

--- a/session/Session.proto
+++ b/session/Session.proto
@@ -111,7 +111,10 @@ message Transaction {
 
     message Batch {
         message Options {
-            int32 batch_size = 1;
+            oneof batch_size {
+                int32 number = 1;
+                bool all = 2;
+            }
         }
         message Req {
             int32 id = 1;

--- a/session/Session.proto
+++ b/session/Session.proto
@@ -65,6 +65,7 @@ message Transaction {
             Open.Req open_req = 1;
             Commit.Req commit_req = 2;
             Query.Req query_req = 3;
+            Batch.Req batch_req = 4;
             GetSchemaConcept.Req getSchemaConcept_req = 5;
             GetConcept.Req getConcept_req = 6;
             GetAttributes.Req getAttributes_req = 7;
@@ -81,11 +82,9 @@ message Transaction {
         oneof res {
             Open.Res open_res = 1;
             Commit.Res commit_res = 2;
-            Query.Iter query_iter = 3;
             Iter.Res iterate_res = 4;
             GetSchemaConcept.Res getSchemaConcept_res = 5;
             GetConcept.Res getConcept_res = 6;
-            GetAttributes.Iter getAttributes_iter = 7;
             PutEntityType.Res putEntityType_res = 8;
             PutAttributeType.Res putAttributeType_res = 9;
             PutRelationType.Res putRelationType_res = 10;

--- a/session/Session.proto
+++ b/session/Session.proto
@@ -65,7 +65,6 @@ message Transaction {
             Open.Req open_req = 1;
             Commit.Req commit_req = 2;
             Query.Req query_req = 3;
-            Iter.Req iterate_req = 4;
             GetSchemaConcept.Req getSchemaConcept_req = 5;
             GetConcept.Req getConcept_req = 6;
             GetAttributes.Req getAttributes_req = 7;
@@ -98,19 +97,26 @@ message Transaction {
     }
 
     message Iter {
-        message Req {
-            int32 id = 1;
-            oneof mode {
-                bool all = 2;
-                int32 batch = 3;
-            }
-        }
         message Res {
             oneof res {
                 bool done = 1;
+                Batch.Res batch_res = 5;
+
                 Query.Iter.Res query_iter_res = 2;
                 GetAttributes.Iter.Res getAttributes_iter_res = 3;
                 Method.Iter.Res conceptMethod_iter_res = 4;
+            }
+        }
+        message Batch {
+            message Options {
+                int32 batch_size = 1;
+            }
+            message Req {
+                int32 id = 1;
+                Options batch_options = 2;
+            }
+            message Res {
+                int32 id = 1;
             }
         }
     }
@@ -127,7 +133,6 @@ message Transaction {
             Type type = 2;
         }
         message Res {}
-
     }
 
     message Commit {
@@ -142,7 +147,7 @@ message Transaction {
             // We cannot use bool for `infer` because GRPC's default value for bool is FALSE
             // We use enum INFER instead, because the default value is index 0 (TRUE)
 
-            int32 iter_id = 3;
+            Iter.Batch.Options batch_options = 3;
         }
         message Iter {
             message Res {
@@ -183,8 +188,6 @@ message Transaction {
     message GetAttributes {
         message Req {
             ValueObject value = 1;
-
-            int32 iter_id = 2;
         }
         message Iter {
             message Res {

--- a/session/Session.proto
+++ b/session/Session.proto
@@ -100,7 +100,7 @@ message Transaction {
     message Iter {
         message Req {
             int32 id = 1;
-            oneof stream_mode {
+            oneof mode {
                 bool all = 2;
                 int32 batch = 3;
             }

--- a/session/Session.proto
+++ b/session/Session.proto
@@ -142,8 +142,7 @@ message Transaction {
             // We cannot use bool for `infer` because GRPC's default value for bool is FALSE
             // We use enum INFER instead, because the default value is index 0 (TRUE)
 
-            int32 id = 3;
-            // Optionally specify iterator id. If not 0, server will not respond and will use this id.
+            int32 iter_id = 3;
         }
         message Iter {
             message Res {
@@ -184,9 +183,10 @@ message Transaction {
     message GetAttributes {
         message Req {
             ValueObject value = 1;
+
+            int32 iter_id = 2;
         }
         message Iter {
-            int32 id = 1;
             message Res {
                 Concept attribute = 1;
             }

--- a/session/Session.proto
+++ b/session/Session.proto
@@ -107,17 +107,18 @@ message Transaction {
                 Method.Iter.Res conceptMethod_iter_res = 4;
             }
         }
-        message Batch {
-            message Options {
-                int32 batch_size = 1;
-            }
-            message Req {
-                int32 id = 1;
-                Options batch_options = 2;
-            }
-            message Res {
-                int32 id = 1;
-            }
+    }
+
+    message Batch {
+        message Options {
+            int32 batch_size = 1;
+        }
+        message Req {
+            int32 id = 1;
+            Options batch_options = 2;
+        }
+        message Res {
+            int32 id = 1;
         }
     }
 
@@ -147,7 +148,7 @@ message Transaction {
             // We cannot use bool for `infer` because GRPC's default value for bool is FALSE
             // We use enum INFER instead, because the default value is index 0 (TRUE)
 
-            Iter.Batch.Options batch_options = 3;
+            Batch.Options batch_options = 3;
         }
         message Iter {
             message Res {


### PR DESCRIPTION
## What is the goal of this PR?

Currently, the protocol only returns IDs for every answer. However, it is very rare to only require the ID for a concept e.g. for an attribute you are most likely interested in its value. The goal of this PR is to mitigate the case where hundreds of concept IDs are returned for Attributes from a query, and the client program is going to do a sync RPC to get the value of each.

## What are the changes implemented in this PR?

By taking a selection of example queries run against protocol, we can determine that there are some common requests that are always bounded (if the returned result is a concept, pre-filling it wouldn't lead to recursion). In the case that the returned concept would cause this kind of explosion, or for some reason the results can't be pre-fetched, the `isPrefilled` field notifies a client that this concept wasn't pre-filled (as opposed to just missing various pre-filled parts). Currently there is no way to explicitly enable pre-filling.

This is a static and simple variation on the "time travelling RPC" concept, where we are returning the results of another RPC call on the result of a first (see Cap'n Proto), although we are a long way from achieving this as a general pattern right now.