### PR TITLE
Updating 2.0 concept protocol

### DIFF
--- a/protobuf/answer.proto
+++ b/protobuf/answer.proto
@@ -79,7 +79,7 @@ message Void {
 }
 
 message ConceptIds {
-    repeated bytes ids = 1;
+    repeated bytes iids = 1;
 }
 
 message Number {

--- a/protobuf/answer.proto
+++ b/protobuf/answer.proto
@@ -79,7 +79,7 @@ message Void {
 }
 
 message ConceptIds {
-    repeated string ids = 1;
+    repeated bytes ids = 1;
 }
 
 message Number {

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -51,8 +51,8 @@ message Method {
 
             // RelationType method requests
             RelationType.Create.Req relationType_create_req = 700;
+            RelationType.Role.Req relationType_role_req = 701;
             RelationType.Relates.Req relationType_relates_req = 702;
-            RelationType.Unrelate.Req relationType_unrelate_req = 703;
 
             // AttributeType method requests
             AttributeType.Create.Req attributeType_put_req = 800;
@@ -103,8 +103,8 @@ message Method {
 
             // RelationType method responses
             RelationType.Create.Res relationType_create_res = 700;
+            RelationType.Role.Res relationType_role_res = 701;
             RelationType.Relates.Res relationType_relates_res = 702;
-            RelationType.Unrelate.Res relationType_unrelate_res = 703;
 
             // AttributeType method responses
             AttributeType.Create.Res attributeType_put_res = 800;
@@ -365,7 +365,7 @@ message ThingType {
         message Iter {
             message Req {
                 oneof filter {
-                    Concept attributeType = 1;
+                    AttributeType.VALUE_TYPE valueType = 1;
                     Null NULL = 2; // TODO: remove Null and replace all of its usage with NOT_SET
                 }
                 bool keysOnly = 3;
@@ -444,6 +444,15 @@ message RelationType {
         }
     }
 
+    message Role {
+        message Req {
+            string label = 1;
+        }
+        message Res {
+            Concept role = 1;
+        }
+    }
+
     message Roles {
         message Iter {
             message Req {}
@@ -455,16 +464,11 @@ message RelationType {
 
     message Relates {
         message Req {
+            string label = 1;
+        }
+        message Res {
             Concept role = 1;
         }
-        message Res {}
-    }
-
-    message Unrelate {
-        message Req {
-            Concept role = 1;
-        }
-        message Res {}
     }
 }
 

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -368,7 +368,7 @@ message ThingType {
                     Concept attributeType = 1;
                     Null NULL = 2; // TODO: remove Null and replace all of its usage with NOT_SET
                 }
-                bool onlyKey = 3;
+                bool keysOnly = 3;
             }
             message Res {
                 Concept attributeType = 1;
@@ -546,21 +546,11 @@ message Thing {
         }
     }
 
-    message Keys {
-        message Iter {
-            message Req {
-                repeated Concept attributeTypes = 1;
-            }
-            message Res {
-                Concept attribute = 1;
-            }
-        }
-    }
-
     message Attributes {
         message Iter {
             message Req {
                 repeated Concept attributeTypes = 1;
+                bool keysOnly = 2;
             }
             message Res {
                 Concept attribute = 1;
@@ -673,9 +663,7 @@ message ValueObject {
     oneof value {
         string string = 1;
         bool boolean = 2;
-        int32 integer = 3;
         int64 long = 4;
-        float float = 5;
         double double = 6;
         int64 datetime = 7; // time since epoch in milliseconds
     }

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -29,24 +29,24 @@ message Method {
             Concept.Delete.Req concept_delete_req = 100;
 
             // SchemaConcept method requests
-            SchemaConcept.GetLabel.Req schemaConcept_getLabel_req = 201;
-            SchemaConcept.SetLabel.Req schemaConcept_setLabel_req = 202;
-            SchemaConcept.GetSup.Req schemaConcept_getSup_req = 203;
-            SchemaConcept.SetSup.Req schemaConcept_setSup_req = 204;
+            Type.GetLabel.Req type_getLabel_req = 201;
+            Type.SetLabel.Req type_setLabel_req = 202;
+            Type.GetSup.Req type_getSup_req = 203;
+            Type.SetSup.Req type_setSup_req = 204;
 
             // Rule method requests
             Rule.When.Req rule_when_req = 300;
             Rule.Then.Req rule_then_req = 301;
 
             // Type method requests
-            Type.IsAbstract.Req type_isAbstract_req = 500;
-            Type.SetAbstract.Req type_setAbstract_req = 501;
-            Type.Has.Req type_has_req = 506;
-            Type.Key.Req type_key_req = 507;
-            Type.Plays.Req type_plays_req = 508;
-            Type.Unhas.Req type_unhas_req = 509;
-            Type.Unkey.Req type_unkey_req = 510;
-            Type.Unplay.Req type_unplay_req = 511;
+            ThingType.IsAbstract.Req thingType_isAbstract_req = 500;
+            ThingType.SetAbstract.Req thingType_setAbstract_req = 501;
+            ThingType.Has.Req thingType_has_req = 506;
+            ThingType.Key.Req thingType_key_req = 507;
+            ThingType.Plays.Req thingType_plays_req = 508;
+            ThingType.Unhas.Req thingType_unhas_req = 509;
+            ThingType.Unkey.Req thingType_unkey_req = 510;
+            ThingType.Unplay.Req thingType_unplay_req = 511;
 
             // EntityType method requests
             EntityType.Create.Req entityType_create_req = 600;
@@ -83,24 +83,24 @@ message Method {
             Concept.Delete.Res concept_delete_res = 100;
 
             // SchemaConcept method responses
-            SchemaConcept.GetLabel.Res schemaConcept_getLabel_res = 201;
-            SchemaConcept.SetLabel.Res schemaConcept_setLabel_res = 202;
-            SchemaConcept.GetSup.Res schemaConcept_getSup_res = 203;
-            SchemaConcept.SetSup.Res schemaConcept_setSup_res = 204;
+            Type.GetLabel.Res type_getLabel_res = 201;
+            Type.SetLabel.Res type_setLabel_res = 202;
+            Type.GetSup.Res type_getSup_res = 203;
+            Type.SetSup.Res type_setSup_res = 204;
 
             // Rule method responses
             Rule.When.Res rule_when_res = 300;
             Rule.Then.Res rule_then_res = 301;
 
             // Type method responses
-            Type.IsAbstract.Res type_isAbstract_res = 500;
-            Type.SetAbstract.Res type_setAbstract_res = 501;
-            Type.Has.Res type_has_res = 506;
-            Type.Key.Res type_key_res = 507;
-            Type.Plays.Res type_plays_res = 508;
-            Type.Unhas.Res type_unhas_res = 509;
-            Type.Unkey.Res type_unkey_res = 510;
-            Type.Unplay.Res type_unplay_res = 511;
+            ThingType.IsAbstract.Res thingType_isAbstract_res = 500;
+            ThingType.SetAbstract.Res thingType_setAbstract_res = 501;
+            ThingType.Has.Res thingType_has_res = 506;
+            ThingType.Key.Res thingType_key_res = 507;
+            ThingType.Plays.Res thingType_plays_res = 508;
+            ThingType.Unhas.Res thingType_unhas_res = 509;
+            ThingType.Unkey.Res thingType_unkey_res = 510;
+            ThingType.Unplay.Res thingType_unplay_res = 511;
 
             // EntityType method responses
             EntityType.Create.Res entityType_create_res = 600;
@@ -136,18 +136,18 @@ message Method {
         message Req {
             oneof req {
                 // SchemaConcept iterator requests
-                SchemaConcept.Sups.Iter.Req schemaConcept_sups_iter_req = 205;
-                SchemaConcept.Subs.Iter.Req schemaConcept_subs_iter_req = 206;
+                Type.Sups.Iter.Req type_sups_iter_req = 205;
+                Type.Subs.Iter.Req type_subs_iter_req = 206;
 
                 // Role iterator requests
                 Role.Relations.Iter.Req role_relations_iter_req = 401;
                 Role.Players.Iter.Req role_players_iter_req = 402;
 
                 // Type iterator requests
-                Type.Instances.Iter.Req type_instances_iter_req = 502;
-                Type.Keys.Iter.Req type_keys_iter_req = 503;
-                Type.Attributes.Iter.Req type_attributes_iter_req = 504;
-                Type.Playing.Iter.Req type_playing_iter_req = 505;
+                ThingType.Instances.Iter.Req thingType_instances_iter_req = 502;
+                ThingType.Keys.Iter.Req thingType_keys_iter_req = 503;
+                ThingType.Attributes.Iter.Req thingType_attributes_iter_req = 504;
+                ThingType.Playing.Iter.Req thingType_playing_iter_req = 505;
 
                 // RelationType iterator requests
                 RelationType.Roles.Iter.Req relationType_roles_iter_req = 701;
@@ -170,18 +170,18 @@ message Method {
         message Res {
             oneof res {
                 // SchemaConcept iterator responses
-                SchemaConcept.Sups.Iter.Res schemaConcept_sups_iter_res = 205;
-                SchemaConcept.Subs.Iter.Res schemaConcept_subs_iter_res = 206;
+                Type.Sups.Iter.Res type_sups_iter_res = 205;
+                Type.Subs.Iter.Res type_subs_iter_res = 206;
 
                 // Role iterator responses
                 Role.Relations.Iter.Res role_relations_iter_res = 401;
                 Role.Players.Iter.Res role_players_iter_res = 402;
 
                 // Type iterator responses
-                Type.Instances.Iter.Res type_instances_iter_res = 502;
-                Type.Keys.Iter.Res type_keys_iter_res = 503;
-                Type.Attributes.Iter.Res type_attributes_iter_res = 504;
-                Type.Playing.Iter.Res type_playing_iter_res = 505;
+                ThingType.Instances.Iter.Res thingType_instances_iter_res = 502;
+                ThingType.Keys.Iter.Res thingType_keys_iter_res = 503;
+                ThingType.Attributes.Iter.Res thingType_attributes_iter_res = 504;
+                ThingType.Playing.Iter.Res thingType_playing_iter_res = 505;
 
                 // RelationType iterator responses
                 RelationType.Roles.Iter.Res relationType_roles_iter_res = 701;
@@ -217,7 +217,7 @@ message Concept {
     Thing.IsInferred.Res inferred_res = 6;
     Attribute.Value.Res value_res = 7;
     AttributeType.ValueType.Res valueType_res = 8;
-    SchemaConcept.GetLabel.Res label_res = 9;
+    Type.GetLabel.Res label_res = 9;
 
     enum BASE_TYPE {
         META_TYPE = 0;
@@ -239,7 +239,7 @@ message Concept {
 
 // SchemaConcept methods
 
-message SchemaConcept {
+message Type {
 
     message GetLabel {
         message Req {}
@@ -259,7 +259,7 @@ message SchemaConcept {
         message Req {}
         message Res {
             oneof res {
-                Concept schemaConcept = 1;
+                Concept type = 1;
                 Null null = 2; // TODO: remove Null and replace all of its usage with NOT_SET
             }
         }
@@ -267,7 +267,7 @@ message SchemaConcept {
 
     message SetSup {
         message Req {
-            Concept schemaConcept = 1;
+            Concept type = 1;
         }
         message Res {}
     }
@@ -276,7 +276,7 @@ message SchemaConcept {
         message Iter {
             message Req {}
             message Res {
-                Concept schemaConcept = 1;
+                Concept type = 1;
             }
         }
     }
@@ -285,7 +285,7 @@ message SchemaConcept {
         message Iter {
             message Req {}
             message Res {
-                Concept schemaConcept = 1;
+                Concept type = 1;
             }
         }
     }
@@ -335,7 +335,7 @@ message Role {
         message Iter {
             message Req {}
             message Res {
-                Concept type = 1;
+                Concept thingType = 1;
             }
         }
     }
@@ -344,7 +344,7 @@ message Role {
 
 // Type methods
 
-message Type {
+message ThingType {
 
     message IsAbstract {
         message Req {}
@@ -562,7 +562,7 @@ message Thing {
     message Type {
         message Req {}
         message Res {
-            Concept type = 1;
+            Concept thingType = 1;
         }
     }
 

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -209,7 +209,7 @@ message Null {}
 // Concept methods
 
 message Concept {
-    string id = 1;
+    bytes id = 1;
     BASE_TYPE baseType = 2;
 
     // Pre-filled responses:

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -141,7 +141,6 @@ message Method {
 
                 // Type iterator requests
                 ThingType.Instances.Iter.Req thingType_instances_iter_req = 502;
-                ThingType.Keys.Iter.Req thingType_keys_iter_req = 503;
                 ThingType.Attributes.Iter.Req thingType_attributes_iter_req = 504;
                 ThingType.Playing.Iter.Req thingType_playing_iter_req = 505;
 
@@ -174,7 +173,6 @@ message Method {
 
                 // Type iterator responses
                 ThingType.Instances.Iter.Res thingType_instances_iter_res = 502;
-                ThingType.Keys.Iter.Res thingType_keys_iter_res = 503;
                 ThingType.Attributes.Iter.Res thingType_attributes_iter_res = 504;
                 ThingType.Playing.Iter.Res thingType_playing_iter_res = 505;
 
@@ -365,16 +363,13 @@ message ThingType {
 
     message Attributes {
         message Iter {
-            message Req {}
-            message Res {
-                Concept attributeType = 1;
+            message Req {
+                oneof filter {
+                    Concept attributeType = 1;
+                    Null NULL = 2; // TODO: remove Null and replace all of its usage with NOT_SET
+                }
+                bool onlyKey = 3;
             }
-        }
-    }
-
-    message Keys {
-        message Iter {
-            message Req {}
             message Res {
                 Concept attributeType = 1;
             }
@@ -390,16 +385,14 @@ message ThingType {
         }
     }
 
-    message Key {
-        message Req {
-            Concept attributeType = 1;
-        }
-        message Res {}
-    }
-
     message Has {
         message Req {
             Concept attributeType = 1;
+            oneof overridden {
+                Concept overriddenType = 2;
+                Null NULL = 3; // TODO: remove Null and replace all of its usage with NOT_SET
+            }
+            bool isKey = 4;
         }
         message Res {}
     }
@@ -407,13 +400,6 @@ message ThingType {
     message Plays {
         message Req {
             Concept role = 1;
-        }
-        message Res {}
-    }
-
-    message Unkey {
-        message Req {
-            Concept attributeType = 1;
         }
         message Res {}
     }

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -42,10 +42,8 @@ message Method {
             ThingType.IsAbstract.Req thingType_isAbstract_req = 500;
             ThingType.SetAbstract.Req thingType_setAbstract_req = 501;
             ThingType.Has.Req thingType_has_req = 506;
-            ThingType.Key.Req thingType_key_req = 507;
             ThingType.Plays.Req thingType_plays_req = 508;
             ThingType.Unhas.Req thingType_unhas_req = 509;
-            ThingType.Unkey.Req thingType_unkey_req = 510;
             ThingType.Unplay.Req thingType_unplay_req = 511;
 
             // EntityType method requests
@@ -57,8 +55,8 @@ message Method {
             RelationType.Unrelate.Req relationType_unrelate_req = 703;
 
             // AttributeType method requests
-            AttributeType.Create.Req attributeType_create_req = 800;
-            AttributeType.Attribute.Req attributeType_attribute_req = 801;
+            AttributeType.Create.Req attributeType_put_req = 800;
+            AttributeType.Attribute.Req attributeType_get_req = 801;
             AttributeType.ValueType.Req attributeType_valueType_req = 802;
             AttributeType.GetRegex.Req attributeType_getRegex_req = 803;
             AttributeType.SetRegex.Req attributeType_setRegex_req = 804;
@@ -70,8 +68,8 @@ message Method {
             Thing.Unhas.Req thing_unhas_req = 907;
 
             // Relation method requests
-            Relation.Assign.Req relation_assign_req = 1002;
-            Relation.Unassign.Req relation_unassign_req = 1003;
+            Relation.Relate.Req relation_relate_req = 1002;
+            Relation.Unrelate.Req relation_unrelate_req = 1003;
 
             // Attribute method requests
             Attribute.Value.Req attribute_value_req = 1100;
@@ -96,10 +94,8 @@ message Method {
             ThingType.IsAbstract.Res thingType_isAbstract_res = 500;
             ThingType.SetAbstract.Res thingType_setAbstract_res = 501;
             ThingType.Has.Res thingType_has_res = 506;
-            ThingType.Key.Res thingType_key_res = 507;
             ThingType.Plays.Res thingType_plays_res = 508;
             ThingType.Unhas.Res thingType_unhas_res = 509;
-            ThingType.Unkey.Res thingType_unkey_res = 510;
             ThingType.Unplay.Res thingType_unplay_res = 511;
 
             // EntityType method responses
@@ -111,8 +107,8 @@ message Method {
             RelationType.Unrelate.Res relationType_unrelate_res = 703;
 
             // AttributeType method responses
-            AttributeType.Create.Res attributeType_create_res = 800;
-            AttributeType.Attribute.Res attributeType_attribute_res = 801;
+            AttributeType.Create.Res attributeType_put_res = 800;
+            AttributeType.Attribute.Res attributeType_get_res = 801;
             AttributeType.ValueType.Res attributeType_valueType_res = 802;
             AttributeType.GetRegex.Res attributeType_getRegex_res = 803;
             AttributeType.SetRegex.Res attributeType_setRegex_res = 804;
@@ -124,8 +120,8 @@ message Method {
             Thing.Unhas.Res thing_unhas_res = 907;
 
             // Relation method responses
-            Relation.Assign.Res relation_assign_res = 1002;
-            Relation.Unassign.Res relation_unassign_res = 1003;
+            Relation.Relate.Res relation_relate_res = 1002;
+            Relation.Unrelate.Res relation_unrelate_res = 1003;
 
             // Attribute method responses
             Attribute.Value.Res attribute_value_res = 1100;
@@ -153,14 +149,13 @@ message Method {
                 RelationType.Roles.Iter.Req relationType_roles_iter_req = 701;
 
                 // Thing iterator requests
-                Thing.Keys.Iter.Req thing_keys_iter_req = 902;
                 Thing.Attributes.Iter.Req thing_attributes_iter_req = 903;
                 Thing.Relations.Iter.Req thing_relations_iter_req = 904;
                 Thing.Roles.Iter.Req thing_roles_iter_req = 905;
 
                 // Relation iterator responses
                 Relation.RolePlayersMap.Iter.Req relation_rolePlayersMap_iter_req = 1000;
-                Relation.RolePlayers.Iter.Req relation_rolePlayers_iter_req = 1001;
+                Relation.Players.Iter.Req relation_players_iter_req = 1001;
 
                 // Attribute iterator requests
                 Attribute.Owners.Iter.Req attribute_owners_iter_req = 1101;
@@ -187,14 +182,13 @@ message Method {
                 RelationType.Roles.Iter.Res relationType_roles_iter_res = 701;
 
                 // Thing iterator responses
-                Thing.Keys.Iter.Res thing_keys_iter_res = 902;
                 Thing.Attributes.Iter.Res thing_attributes_iter_res = 903;
                 Thing.Relations.Iter.Res thing_relations_iter_res = 904;
                 Thing.Roles.Iter.Res thing_roles_iter_res = 905;
 
                 // Relation iterator responses
                 Relation.RolePlayersMap.Iter.Res relation_rolePlayersMap_iter_res = 1000;
-                Relation.RolePlayers.Iter.Res relation_rolePlayers_iter_res = 1001;
+                Relation.Players.Iter.Res relation_players_iter_res = 1001;
 
                 // Attribute iterator responses
                 Attribute.Owners.Iter.Res attribute_owners_iter_res = 1101;
@@ -638,7 +632,7 @@ message Relation {
         }
     }
 
-    message RolePlayers {
+    message Players {
         message Iter {
             message Req {
                 repeated Concept roles = 1;
@@ -649,7 +643,7 @@ message Relation {
         }
     }
 
-    message Assign {
+    message Relate {
         message Req {
             Concept role = 1;
             Concept player = 2;
@@ -657,7 +651,7 @@ message Relation {
         message Res {}
     }
 
-    message Unassign {
+    message Unrelate {
         message Req {
             Concept role = 1;
             Concept player = 2;

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -136,8 +136,8 @@ message Method {
                 Type.Subs.Iter.Req type_subs_iter_req = 206;
 
                 // Role iterator requests
-                Role.Relations.Iter.Req role_relations_iter_req = 401;
-                Role.Players.Iter.Req role_players_iter_req = 402;
+                RoleType.Relations.Iter.Req role_relations_iter_req = 401;
+                RoleType.Players.Iter.Req role_players_iter_req = 402;
 
                 // Type iterator requests
                 ThingType.Instances.Iter.Req thingType_instances_iter_req = 502;
@@ -168,8 +168,8 @@ message Method {
                 Type.Subs.Iter.Res type_subs_iter_res = 206;
 
                 // Role iterator responses
-                Role.Relations.Iter.Res role_relations_iter_res = 401;
-                Role.Players.Iter.Res role_players_iter_res = 402;
+                RoleType.Relations.Iter.Res role_relations_iter_res = 401;
+                RoleType.Players.Iter.Res role_players_iter_res = 402;
 
                 // Type iterator responses
                 ThingType.Instances.Iter.Res thingType_instances_iter_res = 502;
@@ -201,7 +201,7 @@ message Null {}
 // Concept methods
 
 message Concept {
-    bytes id = 1;
+    bytes iid = 1;
     BASE_TYPE baseType = 2;
 
     // Pre-filled responses:
@@ -312,7 +312,7 @@ message Rule {
 
 // Role methods
 
-message Role {
+message RoleType {
 
     message Relations {
         message Iter {

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -153,7 +153,7 @@ message Method {
                 Thing.Roles.Iter.Req thing_roles_iter_req = 905;
 
                 // Relation iterator responses
-                Relation.RolePlayersMap.Iter.Req relation_rolePlayersMap_iter_req = 1000;
+                Relation.PlayersMap.Iter.Req relation_playersMap_iter_req = 1000;
                 Relation.Players.Iter.Req relation_players_iter_req = 1001;
 
                 // Attribute iterator requests
@@ -185,7 +185,7 @@ message Method {
                 Thing.Roles.Iter.Res thing_roles_iter_res = 905;
 
                 // Relation iterator responses
-                Relation.RolePlayersMap.Iter.Res relation_rolePlayersMap_iter_res = 1000;
+                Relation.PlayersMap.Iter.Res relation_playersMap_iter_res = 1000;
                 Relation.Players.Iter.Res relation_players_iter_res = 1001;
 
                 // Attribute iterator responses
@@ -602,7 +602,7 @@ message Thing {
 
 message Relation {
 
-    message RolePlayersMap {
+    message PlayersMap {
         message Iter {
             message Req {}
             message Res {

--- a/protobuf/session.proto
+++ b/protobuf/session.proto
@@ -38,13 +38,13 @@ message Session {
             Options options = 3;
         }
         message Res {
-            bytes sessionID = 1;
+            bytes sessionId = 1;
         }
     }
 
     message Close {
         message Req {
-            bytes sessionID = 1;
+            bytes sessionId = 1;
         }
         message Res {
         }

--- a/protobuf/transaction.proto
+++ b/protobuf/transaction.proto
@@ -38,7 +38,6 @@ message Transaction {
             PutEntityType.Req putEntityType_req = 8;
             PutAttributeType.Req putAttributeType_req = 9;
             PutRelationType.Req putRelationType_req = 10;
-            PutRole.Req putRole_req = 11;
             PutRule.Req putRule_req = 12;
             ConceptMethod.Req conceptMethod_req = 13;
             Explanation.Req explanation_req = 14;
@@ -54,7 +53,6 @@ message Transaction {
             PutEntityType.Res putEntityType_res = 8;
             PutAttributeType.Res putAttributeType_res = 9;
             PutRelationType.Res putRelationType_res = 10;
-            PutRole.Res putRole_res = 11;
             PutRule.Res putRule_res = 12;
             ConceptMethod.Res conceptMethod_res = 13;
             Explanation.Res explanation_res = 14;
@@ -67,7 +65,6 @@ message Transaction {
             oneof req {
                 int32 iteratorId = 2;
                 Query.Iter.Req query_iter_req = 3;
-                GetAttributes.Iter.Req getAttributes_iter_req = 4;
                 ConceptMethod.Iter.Req conceptMethod_iter_req = 5;
             }
             message Options {
@@ -82,7 +79,6 @@ message Transaction {
                 bool done = 1;
                 int32 iteratorId = 2;
                 Query.Iter.Res query_iter_res = 3;
-                GetAttributes.Iter.Res getAttributes_iter_res = 4;
                 ConceptMethod.Iter.Res conceptMethod_iter_res = 5;
             }
         }
@@ -143,17 +139,6 @@ message Transaction {
         }
     }
 
-    message GetAttributes {
-        message Iter {
-            message Req {
-                ValueObject value = 1;
-            }
-            message Res {
-                Concept attribute = 1;
-            }
-        }
-    }
-
     message PutEntityType {
         message Req {
             string label = 1;
@@ -179,15 +164,6 @@ message Transaction {
         }
         message Res {
             Concept relationType = 1;
-        }
-    }
-
-    message PutRole {
-        message Req {
-            string label = 1;
-        }
-        message Res {
-            Concept role = 1;
         }
     }
 

--- a/protobuf/transaction.proto
+++ b/protobuf/transaction.proto
@@ -180,7 +180,7 @@ message Transaction {
 
     message ConceptMethod {
         message Req {
-            bytes id = 1;
+            bytes iid = 1;
             Method.Req method = 2;
         }
         message Res {
@@ -188,7 +188,7 @@ message Transaction {
         }
         message Iter {
             message Req {
-                bytes id = 1;
+                bytes iid = 1;
                 Method.Iter.Req method = 2;
             }
             message Res {

--- a/protobuf/transaction.proto
+++ b/protobuf/transaction.proto
@@ -33,7 +33,7 @@ message Transaction {
             Open.Req open_req = 1;
             Commit.Req commit_req = 2;
             Iter.Req iter_req = 4;
-            GetSchemaConcept.Req getSchemaConcept_req = 5;
+            GetType.Req getType_req = 5;
             GetConcept.Req getConcept_req = 6;
             PutEntityType.Req putEntityType_req = 8;
             PutAttributeType.Req putAttributeType_req = 9;
@@ -49,7 +49,7 @@ message Transaction {
             Open.Res open_res = 1;
             Commit.Res commit_res = 2;
             Iter.Res iter_res = 4;
-            GetSchemaConcept.Res getSchemaConcept_res = 5;
+            GetType.Res getType_res = 5;
             GetConcept.Res getConcept_res = 6;
             PutEntityType.Res putEntityType_res = 8;
             PutAttributeType.Res putAttributeType_res = 9;
@@ -95,7 +95,7 @@ message Transaction {
 
     message Open {
         message Req {
-            bytes sessionID = 1;
+            bytes sessionId = 1;
             Type type = 2;
             Options options = 3;
         }
@@ -119,13 +119,13 @@ message Transaction {
         }
     }
 
-    message GetSchemaConcept {
+    message GetType {
         message Req {
             string label = 1;
         }
         message Res {
             oneof res {
-                Concept schemaConcept = 1;
+                Concept type = 1;
                 Null null = 2; // TODO: remove Null and replace all of its usage with NOT_SET
             }
         }
@@ -133,7 +133,7 @@ message Transaction {
 
     message GetConcept {
         message Req {
-            string id = 1;
+            bytes id = 1;
         }
         message Res {
             oneof res {
@@ -204,7 +204,7 @@ message Transaction {
 
     message ConceptMethod {
         message Req {
-            string id = 1;
+            bytes id = 1;
             Method.Req method = 2;
         }
         message Res {
@@ -212,7 +212,7 @@ message Transaction {
         }
         message Iter {
             message Req {
-                string id = 1;
+                bytes id = 1;
                 Method.Iter.Req method = 2;
             }
             message Res {


### PR DESCRIPTION
## What is the goal of this PR?

To align protocol with the 2.0 Concept API on the server side. A lot of this is simple renaming but some methods have changed slightly. The biggest changes were overridden attributes, roles owned by relations and removal of "key" in favour of parameters for "has".

## What are the changes implemented in this PR?

- Renamed methods to be consistent with 2.0
- Added and removed methods where necessary