### PR TITLE
Split Relation.Players into AllPlayers and PlayersForRoles

### DIFF
--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -613,13 +613,19 @@ message Relation {
         }
     }
 
-    message Players {
+    message AllPlayers {
+        message Iter {
+            message Req {}
+            message Res {
+                Concept thing = 1;
+            }
+        }
+    }
+
+    message PlayersForRoles {
         message Iter {
             message Req {
-                message All {}
-                message ForRoles {
-                    repeated Concept roles = 1;
-                }
+                repeated Concept roles = 1;
             }
             message Res {
                 Concept thing = 1;

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -155,7 +155,7 @@ message Method {
                 // Relation iterator responses
                 Relation.PlayersMap.Iter.Req relation_playersMap_iter_req = 1000;
                 Relation.AllPlayers.Iter.Req relation_allPlayers_iter_req = 1001;
-                Relation.PlayersForRoles.Iter.Req relation_playersForRoles_iter_req_ = 1002;
+                Relation.PlayersForRoles.Iter.Req relation_playersForRoles_iter_req = 1002;
 
                 // Attribute iterator requests
                 Attribute.Owners.Iter.Req attribute_owners_iter_req = 1101;

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -154,7 +154,8 @@ message Method {
 
                 // Relation iterator responses
                 Relation.PlayersMap.Iter.Req relation_playersMap_iter_req = 1000;
-                Relation.Players.Iter.Req relation_players_iter_req = 1001;
+                Relation.Players.Iter.Req.All relation_players_iter_req_all = 1001;
+                Relation.Players.Iter.Req.ForRoles relation_players_iter_req_forRoles = 1002;
 
                 // Attribute iterator requests
                 Attribute.Owners.Iter.Req attribute_owners_iter_req = 1101;
@@ -615,7 +616,10 @@ message Relation {
     message Players {
         message Iter {
             message Req {
-                repeated Concept roles = 1;
+                message All {}
+                message ForRoles {
+                    repeated Concept roles = 1;
+                }
             }
             message Res {
                 Concept thing = 1;

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -154,8 +154,8 @@ message Method {
 
                 // Relation iterator responses
                 Relation.PlayersMap.Iter.Req relation_playersMap_iter_req = 1000;
-                Relation.Players.Iter.Req.All relation_players_iter_req_all = 1001;
-                Relation.Players.Iter.Req.ForRoles relation_players_iter_req_forRoles = 1002;
+                Relation.AllPlayers.Iter.Req relation_allPlayers_iter_req = 1001;
+                Relation.PlayersForRoles.Iter.Req relation_playersForRoles_iter_req_ = 1002;
 
                 // Attribute iterator requests
                 Attribute.Owners.Iter.Req attribute_owners_iter_req = 1101;
@@ -187,7 +187,8 @@ message Method {
 
                 // Relation iterator responses
                 Relation.PlayersMap.Iter.Res relation_playersMap_iter_res = 1000;
-                Relation.Players.Iter.Res relation_players_iter_res = 1001;
+                Relation.AllPlayers.Iter.Res relation_allPlayers_iter_res = 1001;
+                Relation.PlayersForRoles.Iter.Res relation_playersForRoles_iter_res = 1002;
 
                 // Attribute iterator responses
                 Attribute.Owners.Iter.Res attribute_owners_iter_res = 1101;


### PR DESCRIPTION
## What is the goal of this PR?

To fix Relation.players() always returning an empty collection when called from any external Grakn client (e.g. client-java).

## What are the changes implemented in this PR?

In https://github.com/graknlabs/grakn-2.0/pull/13, we updated the Grakn RPC to take in two different kinds of messages for retrieving roleplayers from a relation; one filtered by roles, and one that isn't.

Then we updated the protocol to represent the new message format, splitting Relation.Players into AllPlayers and PlayersForRoles.