### PR TITLE
Remove sync-dependencies from workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,19 +146,11 @@ workflows:
           filters:
             branches:
               only: master
-#      - sync-dependencies-snapshot:
-#          filters:
-#            branches:
-#              only: master
-#          requires:
-#            - build
-#            - deploy-maven-snapshot
       - release-approval:
           filters:
             branches:
               only: master
           requires:
-#            - sync-dependencies-snapshot
             - build
             - deploy-maven-snapshot
 
@@ -182,16 +174,9 @@ workflows:
               only: protocol-release-branch
           requires:
             - deploy-approval
-#      - sync-dependencies-release:
-#          filters:
-#            branches:
-#              only: protocol-release-branch
-#          requires:
-#            - deploy-maven
       - release-cleanup:
           filters:
             branches:
               only: protocol-release-branch
           requires:
-#            - sync-dependencies-release
             - deploy-maven

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,12 +146,13 @@ workflows:
           filters:
             branches:
               only: master
+          requires:
+            - build
       - release-approval:
           filters:
             branches:
               only: master
           requires:
-            - build
             - deploy-maven-snapshot
 
 


### PR DESCRIPTION
## What is the goal of this PR?

We have removed sync-dependencies completely (it was already commented-out). It will be replaced by Grabl 2.0's sync pipeline soon.