### PR TITLE
Assemble maven from bazel_distribution

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,7 +20,7 @@ workspace(name = "graknlabs_protocol")
 ################################
 # Load @graknlabs_dependencies #
 ################################
-load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_dependencies")
+load("//dependencies/graknlabs:repositories.bzl", "graknlabs_dependencies")
 graknlabs_dependencies()
 
 # Load Antlr
@@ -30,9 +30,7 @@ load("@rules_antlr//antlr:deps.bzl", "antlr_dependencies")
 antlr_dependencies()
 
 # Load Bazel
-load("@graknlabs_dependencies//builder/bazel:deps.bzl","bazel_common", "bazel_deps", "bazel_toolchain")
-bazel_common()
-bazel_deps()
+load("@graknlabs_dependencies//builder/bazel:deps.bzl", "bazel_toolchain")
 bazel_toolchain()
 
 # Load gRPC
@@ -93,11 +91,16 @@ sonarcloud_dependencies()
 load("@graknlabs_dependencies//tool/unuseddeps:deps.bzl", unuseddeps_deps = "deps")
 unuseddeps_deps()
 
-#####################################################################
-# Load @graknlabs_bazel_distribution from (@graknlabs_dependencies) #
-#####################################################################
 load("@graknlabs_dependencies//distribution:deps.bzl", distribution_deps = "deps")
 distribution_deps()
+
+
+######################################
+# Load @graknlabs_bazel_distribution #
+######################################
+
+load("//dependencies/graknlabs:repositories.bzl", "graknlabs_bazel_distribution")
+graknlabs_bazel_distribution()
 
 pip3_import(
     name = "graknlabs_bazel_distribution_pip",
@@ -139,6 +142,7 @@ rules_pkg_dependencies()
 # Load @maven #
 ###############
 load("//dependencies/maven:artifacts.bzl", "artifacts")
+# TODO should we be including the overrides as in client-java?
 maven(artifacts)
 
 #############################################

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -17,9 +17,19 @@
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
+def graknlabs_bazel_distribution():
+    native.local_repository(
+        name = "graknlabs_bazel_distribution",
+        path = "../bazel-distribution",
+    )
+
 def graknlabs_dependencies():
-    git_repository(
+#    git_repository(
+#        name = "graknlabs_dependencies",
+#        remote = "https://github.com/graknlabs/dependencies",
+#        commit = "d0f58a02b052b008a90564a01533eea265221ff2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+#    )
+    native.local_repository(
         name = "graknlabs_dependencies",
-        remote = "https://github.com/graknlabs/dependencies",
-        commit = "2c1c17ecf27374f603ade164f1cf2724b3c47d5d", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        path = "../dependencies",
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -18,18 +18,15 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def graknlabs_bazel_distribution():
-    native.local_repository(
+    git_repository(
         name = "graknlabs_bazel_distribution",
-        path = "../bazel-distribution",
+        remote = "https://github.com/graknlabs/bazel-distribution",
+        commit = "30e30cec9e3fe4821103cafbd240ee9862e262ea" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_bazel_distribution
     )
 
 def graknlabs_dependencies():
-#    git_repository(
-#        name = "graknlabs_dependencies",
-#        remote = "https://github.com/graknlabs/dependencies",
-#        commit = "d0f58a02b052b008a90564a01533eea265221ff2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
-#    )
-    native.local_repository(
+    git_repository(
         name = "graknlabs_dependencies",
-        path = "../dependencies",
+        remote = "https://github.com/graknlabs/dependencies",
+        commit = "07127f135b7f3a1f9a18ab44aba69fa0169df1dc", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )

--- a/grpc/java/BUILD
+++ b/grpc/java/BUILD
@@ -17,7 +17,8 @@
 
 package(default_visibility = ["//visibility:public"])
 load("@stackb_rules_proto//java:java_grpc_compile.bzl", "java_grpc_compile")
-load("@graknlabs_dependencies//distribution/maven:rules.bzl", "assemble_maven", "deploy_maven")
+load("@graknlabs_bazel_distribution//maven:rules.bzl", "assemble_maven", "deploy_maven")
+load("@graknlabs_dependencies//library/maven:artifacts.bzl", "maven_overrides", maven_overrides_org = "artifacts")
 
 java_grpc_compile(
     name = "protocol-src",
@@ -47,12 +48,14 @@ assemble_maven(
     name = "assemble-maven",
     target = ":protocol",
     package = "grpc",
+    version_overrides = maven_overrides(maven_overrides_org),
     workspace_refs = "@graknlabs_protocol_workspace_refs//:refs.json"
 )
 
 deploy_maven(
     name = "deploy-maven",
-    target = ":assemble-maven"
+    target = ":assemble-maven",
+    deployment_properties = "@graknlabs_dependencies//distribution:deployment.properties",
 )
 
 # --- KGMS console dependencies


### PR DESCRIPTION
## What is the goal of this PR?
Following the implemation of https://github.com/graknlabs/bazel-distribution/pull/248, we can directly depend on `bazel_distribution` for `assemble-maven` and `deploy-maven` rules, and no longer use `graknlabs_dependencies` for this.



## What are the changes implemented in this PR?
* use new implemetatnion of `assemble-maven` with argument for maven overrides