### PR TITLE
Remove prefilled responses from Thing/Type and slim them down to only the data necessary for a client to construct Things and Types

### DIFF
--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -111,19 +111,11 @@ message ThingMethod {
 
 message Thing {
     bytes iid = 1;
-    SCHEMA schema = 2;
-    Type type = 3;
-    AttributeType.VALUE_TYPE valueType = 4;
+    Type type = 2;
 
     // Pre-filled responses:
-    Thing.IsInferred.Res inferred_res = 5;
-    Attribute.GetValue.Res value_res = 6;
-
-    enum SCHEMA {
-        ENTITY = 0;
-        RELATION = 1;
-        ATTRIBUTE = 2;
-    }
+    Thing.IsInferred.Res inferred_res = 3;
+    Attribute.GetValue.Res value_res = 4;
 
     message Delete {
         message Req {}

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -247,7 +247,6 @@ message Attribute {
             message Req {
                 oneof filter {
                     Type thingType = 1;
-                    Null null = 2;
                 }
             }
             message Res {
@@ -427,7 +426,6 @@ message Type {
         message Res {
             oneof res {
                 Type type = 1;
-                Null null = 2; // TODO: remove Null and replace all of its usage with NOT_SET
             }
         }
     }
@@ -468,7 +466,6 @@ message Rule {
         message Res {
             oneof res {
                 string pattern = 1;
-                Null null = 2; // TODO: remove Null and replace all of its usage with NOT_SET
             }
         }
     }
@@ -478,7 +475,6 @@ message Rule {
         message Res {
             oneof res {
                 string pattern = 1;
-                Null null = 2; // TODO: remove Null and replace all of its usage with NOT_SET
             }
         }
     }
@@ -551,7 +547,6 @@ message ThingType {
             message Req {
                 oneof filter {
                     AttributeType.VALUE_TYPE valueType = 1;
-                    Null NULL = 2; // TODO: remove Null and replace all of its usage with NOT_SET
                 }
                 bool keysOnly = 3;
             }
@@ -575,7 +570,6 @@ message ThingType {
             Type attributeType = 1;
             oneof overridden {
                 Type overriddenType = 2;
-                Null NULL = 3; // TODO: remove Null and replace all of its usage with NOT_SET
             }
             bool isKey = 4;
         }
@@ -686,7 +680,6 @@ message AttributeType {
         message Res {
             oneof res {
                 Thing attribute = 1;
-                Null null = 2; // TODO: remove Null and replace all of its usage with NOT_SET
             }
         }
     }
@@ -705,7 +698,3 @@ message AttributeType {
         message Res {}
     }
 }
-
-
-// TODO: remove Null and replace all of its usage with NOT_SET
-message Null {}

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -111,11 +111,15 @@ message ThingMethod {
 
 message Thing {
     bytes iid = 1;
-    Type type = 2;
+    SCHEMA schema = 2;
+    AttributeType.VALUE_TYPE valueType = 3;
+    Attribute.Value value = 4;
 
-    // Pre-filled responses:
-    Thing.IsInferred.Res inferred_res = 3;
-    Attribute.GetValue.Res value_res = 4;
+    enum SCHEMA {
+        ENTITY = 0;
+        RELATION = 1;
+        ATTRIBUTE = 2;
+    }
 
     message Delete {
         message Req {}
@@ -234,7 +238,7 @@ message Attribute {
     message GetValue {
         message Req {}
         message Res {
-            ValueObject value = 1;
+            Value value = 1;
         }
     }
 
@@ -249,6 +253,16 @@ message Attribute {
             message Res {
                 Thing thing = 1;
             }
+        }
+    }
+
+    message Value {
+        oneof value {
+            string string = 1;
+            bool boolean = 2;
+            int64 long = 4;
+            double double = 6;
+            int64 datetime = 7; // time since epoch in milliseconds
         }
     }
 }
@@ -657,7 +671,7 @@ message AttributeType {
 
     message Put {
         message Req {
-            ValueObject value = 1;
+            Attribute.Value value = 1;
         }
         message Res {
             Thing attribute = 1;
@@ -666,7 +680,7 @@ message AttributeType {
 
     message Get {
         message Req {
-            ValueObject value = 1;
+            Attribute.Value value = 1;
         }
         message Res {
             oneof res {
@@ -694,16 +708,3 @@ message AttributeType {
 
 // TODO: remove Null and replace all of its usage with NOT_SET
 message Null {}
-
-
-// Attribute Value object
-
-message ValueObject {
-    oneof value {
-        string string = 1;
-        bool boolean = 2;
-        int64 long = 4;
-        double double = 6;
-        int64 datetime = 7; // time since epoch in milliseconds
-    }
-}

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -399,6 +399,7 @@ message Type {
     SCHEMA schema = 2;
     AttributeType.VALUE_TYPE valueType = 3;
     bool root = 4;
+    string scopedLabel = 5;
 
     enum SCHEMA {
         THING_TYPE = 0;

--- a/protobuf/transaction.proto
+++ b/protobuf/transaction.proto
@@ -126,19 +126,17 @@ message Transaction {
         message Res {
             oneof res {
                 grakn.protocol.Type type = 1;
-                Null null = 2; // TODO: remove Null and replace all of its usage with NOT_SET
             }
         }
     }
 
     message GetThing {
         message Req {
-            bytes id = 1;
+            bytes iid = 1;
         }
         message Res {
             oneof res {
                 Thing thing = 1;
-                Null null = 2; // TODO: remove Null and replace all of its usage with NOT_SET
             }
         }
     }


### PR DESCRIPTION
## What is the goal of this PR?

To remove prefilled responses from Thing/Type and slim them down to only the data necessary for a client to construct Things and Types.

We also fix https://github.com/graknlabs/protocol/issues/37 by deleting NULL and replacing it with XXX_NOT_SET when used in the clients and server.

## What are the changes implemented in this PR?

Changed `Thing` to include the following fields:

- **iid** - used to uniquely identify the Thing
- **schema** - either Entity, Relation, or Attribute, used to construct an instance of the Thing
- **valueType** - either Boolean, Long, Double, String, or DateTime, used to construct an Attribute instance
- **value** - the attribute's value, a fundamental property of Attributes

Changed `Type` to include the following fields:

- **label** - used to uniquely identify the Type, unless it is a RoleType
- **schema** - used to construct the Type
- **valueType** - used to construct AttributeTypes
- **root** - a fundamental property of Types
- **scopedLabel** - used to uniquely identify a RoleType