### PR TITLE
Refactor: clean up to use 2.0 build dependencies 

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -19,10 +19,12 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files(["VERSION"])
 load("@graknlabs_bazel_distribution//github:rules.bzl", "deploy_github")
+load("//:deployment.bzl", "deployment")
 
 deploy_github(
     name = "deploy-github",
-    deployment_properties = "//:deployment.properties",
+    organisation = deployment["organisation"],
+    repository = deployment["repository"],
     release_description = "//:RELEASE_TEMPLATE.md",
     title = "Protocol",
     title_append_version = True,

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -59,7 +59,7 @@ kt_register_toolchains()
 # Load NodeJS
 load("@graknlabs_dependencies//builder/nodejs:deps.bzl", nodejs_deps = "deps")
 nodejs_deps()
-load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
+load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
 node_repositories()
 
 # Load Python
@@ -79,15 +79,11 @@ graknlabs_dependencies_ci_pip_install()
 load("@graknlabs_dependencies//tool/unuseddeps:deps.bzl", unuseddeps_deps = "deps")
 unuseddeps_deps()
 
-load("@graknlabs_dependencies//distribution:deps.bzl", distribution_deps = "deps")
-distribution_deps()
-
-
 ######################################
 # Load @graknlabs_bazel_distribution #
 ######################################
 
-load("//dependencies/graknlabs:repositories.bzl", "graknlabs_bazel_distribution")
+load("@graknlabs_dependencies//dependencies/graknlabs:repositories.bzl", "graknlabs_bazel_distribution")
 graknlabs_bazel_distribution()
 
 pip3_import(

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -17,16 +17,9 @@
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
-def graknlabs_bazel_distribution():
-    git_repository(
-        name = "graknlabs_bazel_distribution",
-        remote = "https://github.com/graknlabs/bazel-distribution",
-        commit = "30e30cec9e3fe4821103cafbd240ee9862e262ea" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_bazel_distribution
-    )
-
 def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "07127f135b7f3a1f9a18ab44aba69fa0169df1dc", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "2680ead7ed779bf2835953852789dfeb3f25d7a5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )

--- a/deployment.bzl
+++ b/deployment.bzl
@@ -15,5 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-repo.github.organisation=graknlabs
-repo.github.repository=protocol
+deployment = {
+    "organisation": "graknlabs",
+    "repository": "protocol"
+}

--- a/grpc/java/BUILD
+++ b/grpc/java/BUILD
@@ -19,6 +19,7 @@ package(default_visibility = ["//visibility:public"])
 load("@stackb_rules_proto//java:java_grpc_compile.bzl", "java_grpc_compile")
 load("@graknlabs_bazel_distribution//maven:rules.bzl", "assemble_maven", "deploy_maven")
 load("@graknlabs_dependencies//library/maven:artifacts.bzl", "maven_overrides", maven_overrides_org = "artifacts")
+load("@graknlabs_dependencies//distribution:deployment.bzl", "deployment")
 
 java_grpc_compile(
     name = "protocol-src",
@@ -58,5 +59,6 @@ assemble_maven(
 deploy_maven(
     name = "deploy-maven",
     target = ":assemble-maven",
-    deployment_properties = "@graknlabs_dependencies//distribution:deployment.properties",
+    snapshot = deployment["maven.snapshot"],
+    release = deployment["maven.release"],
 )


### PR DESCRIPTION
## What is the goal of this PR?
Update to use cleaned up assemble-maven, deployment targets, and new format of deployment properties in `deployment.bzl`

