### PR TITLE
Align Type methods in protocol with core

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -22,6 +22,9 @@ build:
         machine: graknlabs-ubuntu-20.04
         script: |
           bazel build //...
+      build-dependency:
+        machine: graknlabs-ubuntu-20.04
+        script: |
           dependencies/maven/update.sh
           git diff --exit-code dependencies/maven/artifacts.snapshot
           bazel run @graknlabs_dependencies//tool/unuseddeps:unused-deps -- list
@@ -36,5 +39,6 @@ build:
           bazel run --define version=$(git rev-parse HEAD) //grpc/java:deploy-maven -- snapshot
     execution:
       - build
+      - build-dependency
       - deploy-maven-snapshot:
-          depends: [build]
+          depends: [build, build-dependency]

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -1,0 +1,40 @@
+#
+# Copyright (C) 2020 Grakn Labs
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+build:
+  correctness:
+    jobs:
+      build:
+        machine: graknlabs-ubuntu-20.04
+        script: |
+          bazel build //...
+          dependencies/maven/update.sh
+          git diff --exit-code dependencies/maven/artifacts.snapshot
+          bazel run @graknlabs_dependencies//tool/unuseddeps:unused-deps -- list
+      deploy-maven-snapshot:
+        filter:
+          owner: graknlabs
+          branch: master
+        machine: graknlabs-ubuntu-20.04
+        script: |
+          export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
+          export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
+          bazel run --define version=$(git rev-parse HEAD) //grpc/java:deploy-maven -- snapshot
+    execution:
+      - build
+      - deploy-maven-snapshot:
+          depends: [build]

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -301,6 +301,7 @@ message TypeMethod {
             RelationType.Create.Req relationType_create_req = 700;
             RelationType.GetRelatesForRoleLabel.Req relationType_getRelatesForRoleLabel_req = 701;
             RelationType.SetRelates.Req relationType_setRelates_req = 702;
+            RelationType.UnsetRelates.Req relationType_unsetRelates_req = 703;
 
             // AttributeType method requests
             AttributeType.Put.Req attributeType_put_req = 800;
@@ -340,6 +341,7 @@ message TypeMethod {
             RelationType.Create.Res relationType_create_res = 700;
             RelationType.GetRelatesForRoleLabel.Res relationType_getRelatesForRoleLabel_res = 701;
             RelationType.SetRelates.Res relationType_setRelates_res = 702;
+            RelationType.UnsetRelates.Res relationType_unsetRelates_res = 703;
 
             // AttributeType method responses
             AttributeType.Put.Res attributeType_put_res = 800;
@@ -367,6 +369,9 @@ message TypeMethod {
 
                 // RelationType iterator requests
                 RelationType.GetRelates.Iter.Req relationType_getRelates_iter_req = 701;
+
+                // AttributeType iterator requests
+                AttributeType.GetOwners.Iter.Req attributeType_getOwners_iter_req = 800;
             }
         }
 
@@ -387,6 +392,9 @@ message TypeMethod {
 
                 // RelationType iterator responses
                 RelationType.GetRelates.Iter.Res relationType_getRelates_iter_res = 701;
+
+                // AttributeType iterator responses
+                AttributeType.GetOwners.Iter.Res attributeType_getOwners_iter_res = 800;
             }
         }
     }
@@ -655,6 +663,13 @@ message RelationType {
         }
         message Res {}
     }
+
+    message UnsetRelates {
+        message Req {
+            string label = 1;
+        }
+        message Res {}
+    }
 }
 
 
@@ -687,6 +702,17 @@ message AttributeType {
         message Res {
             oneof res {
                 Thing attribute = 1;
+            }
+        }
+    }
+
+    message GetOwners {
+        message Iter {
+            message Req {
+                bool onlyKey = 1;
+            }
+            message Res {
+                Type owner = 1;
             }
         }
     }

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -275,8 +275,9 @@ message TypeMethod {
             // Type method requests
             Type.Delete.Req type_delete_req = 200;
             Type.SetLabel.Req type_setLabel_req = 201;
-            Type.GetSupertype.Req type_getSupertype_req = 202;
-            Type.SetSupertype.Req type_setSupertype_req = 203;
+            Type.IsAbstract.Req type_isAbstract_req = 202;
+            Type.GetSupertype.Req type_getSupertype_req = 203;
+            Type.SetSupertype.Req type_setSupertype_req = 204;
 
             // Rule method requests
             Rule.When.Req rule_when_req = 300;
@@ -286,7 +287,6 @@ message TypeMethod {
             RoleType.GetRelation.Req roleType_getRelation_req = 400;
 
             // ThingType method requests
-            ThingType.IsAbstract.Req thingType_isAbstract_req = 500;
             ThingType.SetAbstract.Req thingType_setAbstract_req = 501;
             ThingType.UnsetAbstract.Req thingType_unsetAbstract_req = 502;
             ThingType.SetOwns.Req thingType_setOwns_req = 506;
@@ -314,8 +314,9 @@ message TypeMethod {
             // Type method responses
             Type.Delete.Res type_delete_res = 200;
             Type.SetLabel.Res type_setLabel_res = 201;
-            Type.GetSupertype.Res type_getSupertype_res = 202;
-            Type.SetSupertype.Res type_setSupertype_res = 203;
+            Type.IsAbstract.Res type_isAbstract_res = 202;
+            Type.GetSupertype.Res type_getSupertype_res = 203;
+            Type.SetSupertype.Res type_setSupertype_res = 204;
 
             // Rule method responses
             Rule.When.Res rule_when_res = 300;
@@ -325,7 +326,6 @@ message TypeMethod {
             RoleType.GetRelation.Res roleType_getRelation_res = 400;
 
             // ThingType method responses
-            ThingType.IsAbstract.Res thingType_isAbstract_res = 500;
             ThingType.SetAbstract.Res thingType_setAbstract_res = 501;
             ThingType.UnsetAbstract.Res thingType_unsetAbstract_res = 502;
             ThingType.SetOwns.Res thingType_setOwns_res = 506;
@@ -420,7 +420,7 @@ message Type {
         }
         message Res {}
     }
-    
+
     message IsAbstract {
         message Req {}
         message Res {

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -647,6 +647,9 @@ message RelationType {
     message SetRelates {
         message Req {
             string label = 1;
+            oneof overridden {
+                string overriddenLabel = 2;
+            }
         }
         message Res {
             Type role = 1;

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -579,6 +579,9 @@ message ThingType {
     message SetPlays {
         message Req {
             Type role = 1;
+            oneof overridden {
+                Type overriddenRole = 2;
+            }
         }
         message Res {}
     }

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -657,11 +657,12 @@ message RelationType {
 message AttributeType {
 
     enum VALUE_TYPE {
-        BOOLEAN = 0;
-        LONG = 1;
-        DOUBLE = 2;
-        STRING = 3;
-        DATETIME = 4;
+        OBJECT = 0;
+        BOOLEAN = 1;
+        LONG = 2;
+        DOUBLE = 3;
+        STRING = 4;
+        DATETIME = 5;
     }
 
     message Put {

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -651,9 +651,7 @@ message RelationType {
                 string overriddenLabel = 2;
             }
         }
-        message Res {
-            Type role = 1;
-        }
+        message Res {}
     }
 }
 

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -420,6 +420,13 @@ message Type {
         }
         message Res {}
     }
+    
+    message IsAbstract {
+        message Req {}
+        message Res {
+            bool abstract = 1;
+        }
+    }
 
     message GetSupertype {
         message Req {}
@@ -515,13 +522,6 @@ message RoleType {
 // ThingType methods
 
 message ThingType {
-
-    message IsAbstract {
-        message Req {}
-        message Res {
-            bool abstract = 1;
-        }
-    }
 
     message SetAbstract {
         message Req {}

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -640,7 +640,9 @@ message RelationType {
             string label = 1;
         }
         message Res {
-            Type role = 1;
+            oneof role {
+                Type roleType = 1;
+            }
         }
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

To align the Type methods in protocol with core.

## What are the changes implemented in this PR?

- Add VALUE_TYPE.OBJECT
- Add support for role overrides
- Make SetRelates response empty
- Allow GetRelatesForRoleLabel to return null
- Pull IsAbstract up from ThingType to Type (but SetAbstract remains in ThingType)
- Add GetOwners to AttributeType
- Add UnsetRelates to RelationType

We also set up `protocol` for CI/CD using grabl.io.
