### PR TITLE
Rename schema to encoding to match grakn 2.0

### DIFF
--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -391,7 +391,7 @@ message TypeMethod {
 message Type {
     string label = 1;
     string scope = 2;
-    ENCODING ENCODING = 3;
+    ENCODING encoding = 3;
     AttributeType.VALUE_TYPE valueType = 4;
     bool root = 5;
 

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -105,11 +105,11 @@ message ThingMethod {
 
 message Thing {
     bytes iid = 1;
-    SCHEMA schema = 2;
+    ENCODING encoding = 2;
     AttributeType.VALUE_TYPE valueType = 3;
     Attribute.Value value = 4;
 
-    enum SCHEMA {
+    enum ENCODING {
         ENTITY = 0;
         RELATION = 1;
         ATTRIBUTE = 2;
@@ -391,11 +391,11 @@ message TypeMethod {
 message Type {
     string label = 1;
     string scope = 2;
-    SCHEMA schema = 3;
+    ENCODING ENCODING = 3;
     AttributeType.VALUE_TYPE valueType = 4;
     bool root = 5;
 
-    enum SCHEMA {
+    enum ENCODING {
         THING_TYPE = 0;
         ENTITY_TYPE = 1;
         RELATION_TYPE = 2;


### PR DESCRIPTION
## What is the goal of this PR?
Following https://github.com/graknlabs/grakn-2.0/pull/35, we align terminology to not use `schema` but `encoding` for concept root type information.

## What are the changes implemented in this PR?
Rename `schema` to `encoding` to match terminology in grakn 2.0