### PR TITLE
Rules are not types and gRPC field compaction

### DIFF
--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -32,76 +32,105 @@ message Concept {
     }
 }
 
+// Type
 
-// Thing
+message Type {
+    string label = 1;
+    string scope = 2;
+    ENCODING encoding = 3;
+    AttributeType.VALUE_TYPE valueType = 4;
+    bool root = 5;
 
-message ThingMethod {
-    message Req {
-        oneof req {
-            // Thing method requests
-            Thing.Delete.Req thing_delete_req = 900;
-            Thing.GetType.Req thing_getType_req = 901;
-            Thing.IsInferred.Req thing_isInferred_req = 902;
-            Thing.SetHas.Req thing_setHas_req = 906;
-            Thing.UnsetHas.Req thing_unsetHas_req = 907;
-
-            // Relation method requests
-            Relation.AddPlayer.Req relation_addPlayer_req = 1002;
-            Relation.RemovePlayer.Req relation_removePlayer_req = 1003;
-        }
-    }
-    message Res {
-        oneof res {
-            // Thing method responses
-            Thing.Delete.Res thing_delete_res = 900;
-            Thing.GetType.Res thing_getType_res = 901;
-            Thing.IsInferred.Res thing_isInferred_res = 902;
-            Thing.SetHas.Res thing_setHas_res = 906;
-            Thing.UnsetHas.Res thing_unsetHas_res = 907;
-
-            // Relation method responses
-            Relation.AddPlayer.Res relation_addPlayer_res = 1002;
-            Relation.RemovePlayer.Res relation_removePlayer_res = 1003;
-        }
+    enum ENCODING {
+        THING_TYPE = 0;
+        ENTITY_TYPE = 1;
+        RELATION_TYPE = 2;
+        ATTRIBUTE_TYPE = 3;
+        ROLE_TYPE = 4;
     }
 
-    message Iter {
+    message Delete {
+        message Req {}
+        message Res {}
+    }
+
+    message SetLabel {
         message Req {
-            oneof req {
-                // Thing iterator requests
-                Thing.GetHas.Iter.Req thing_getHas_iter_req = 903;
-                Thing.GetRelations.Iter.Req thing_getRelations_iter_req = 904;
-                Thing.GetPlays.Iter.Req thing_getPlays_iter_req = 905;
-
-                // Relation iterator responses
-                Relation.GetPlayers.Iter.Req relation_getPlayers_iter_req = 1000;
-                Relation.GetPlayersByRoleType.Iter.Req relation_getPlayersByRoleType_iter_req = 1001;
-
-                // Attribute iterator requests
-                Attribute.GetOwners.Iter.Req attribute_getOwners_iter_req = 1101;
-            }
+            string label = 1;
         }
+        message Res {}
+    }
 
+    message IsAbstract {
+        message Req {}
+        message Res {
+            bool abstract = 1;
+        }
+    }
+
+    message GetSupertype {
+        message Req {}
         message Res {
             oneof res {
-                // Thing iterator responses
-                Thing.GetHas.Iter.Res thing_getHas_iter_res = 903;
-                Thing.GetRelations.Iter.Res thing_getRelations_iter_res = 904;
-                Thing.GetPlays.Iter.Res thing_getPlays_iter_res = 905;
+                Type type = 1;
+            }
+        }
+    }
 
-                // Relation iterator responses
-                Relation.GetPlayers.Iter.Res relation_getPlayers_iter_res = 1000;
-                Relation.GetPlayersByRoleType.Iter.Res relation_getPlayersByRoleType_iter_res = 1001;
+    message SetSupertype {
+        message Req {
+            Type type = 1;
+        }
+        message Res {}
+    }
 
-                // Attribute iterator responses
-                Attribute.GetOwners.Iter.Res attribute_getOwners_iter_res = 1101;
+    message GetSupertypes {
+        message Iter {
+            message Req {}
+            message Res {
+                Type type = 1;
+            }
+        }
+    }
+
+    message GetSubtypes {
+        message Iter {
+            message Req {}
+            message Res {
+                Type type = 1;
+            }
+        }
+    }
+}
+
+// Rule
+
+message Rule {
+    string label = 1;
+    string when = 2;
+    string then = 3;
+
+    message When {
+        message Req {}
+        message Res {
+            oneof res {
+                string pattern = 1;
+            }
+        }
+    }
+
+    message Then {
+        message Req {}
+        message Res {
+            oneof res {
+                string pattern = 1;
             }
         }
     }
 }
 
 
-// Thing methods
+// Thing
 
 message Thing {
     bytes iid = 1;
@@ -181,6 +210,75 @@ message Thing {
     }
 }
 
+// Thing methods
+
+message ThingMethod {
+    message Req {
+        oneof req {
+            // Thing method requests
+            Thing.Delete.Req thing_delete_req = 900;
+            Thing.GetType.Req thing_getType_req = 901;
+            Thing.IsInferred.Req thing_isInferred_req = 902;
+            Thing.SetHas.Req thing_setHas_req = 906;
+            Thing.UnsetHas.Req thing_unsetHas_req = 907;
+
+            // Relation method requests
+            Relation.AddPlayer.Req relation_addPlayer_req = 1002;
+            Relation.RemovePlayer.Req relation_removePlayer_req = 1003;
+        }
+    }
+    message Res {
+        oneof res {
+            // Thing method responses
+            Thing.Delete.Res thing_delete_res = 900;
+            Thing.GetType.Res thing_getType_res = 901;
+            Thing.IsInferred.Res thing_isInferred_res = 902;
+            Thing.SetHas.Res thing_setHas_res = 906;
+            Thing.UnsetHas.Res thing_unsetHas_res = 907;
+
+            // Relation method responses
+            Relation.AddPlayer.Res relation_addPlayer_res = 1002;
+            Relation.RemovePlayer.Res relation_removePlayer_res = 1003;
+        }
+    }
+
+    message Iter {
+        message Req {
+            oneof req {
+                // Thing iterator requests
+                Thing.GetHas.Iter.Req thing_getHas_iter_req = 903;
+                Thing.GetRelations.Iter.Req thing_getRelations_iter_req = 904;
+                Thing.GetPlays.Iter.Req thing_getPlays_iter_req = 905;
+
+                // Relation iterator responses
+                Relation.GetPlayers.Iter.Req relation_getPlayers_iter_req = 1000;
+                Relation.GetPlayersByRoleType.Iter.Req relation_getPlayersByRoleType_iter_req = 1001;
+
+                // Attribute iterator requests
+                Attribute.GetOwners.Iter.Req attribute_getOwners_iter_req = 1101;
+            }
+        }
+
+        message Res {
+            oneof res {
+                // Thing iterator responses
+                Thing.GetHas.Iter.Res thing_getHas_iter_res = 903;
+                Thing.GetRelations.Iter.Res thing_getRelations_iter_res = 904;
+                Thing.GetPlays.Iter.Res thing_getPlays_iter_res = 905;
+
+                // Relation iterator responses
+                Relation.GetPlayers.Iter.Res relation_getPlayers_iter_res = 1000;
+                Relation.GetPlayersByRoleType.Iter.Res relation_getPlayersByRoleType_iter_res = 1001;
+
+                // Attribute iterator responses
+                Attribute.GetOwners.Iter.Res attribute_getOwners_iter_res = 1101;
+            }
+        }
+    }
+}
+
+
+
 
 // Relation methods
 
@@ -254,87 +352,79 @@ message Attribute {
 }
 
 
-// Type
+// Type methods
 
 message TypeMethod {
     message Req {
         oneof req {
             // Type method requests
-            Type.Delete.Req type_delete_req = 200;
-            Type.SetLabel.Req type_setLabel_req = 201;
-            Type.IsAbstract.Req type_isAbstract_req = 202;
-            Type.GetSupertype.Req type_getSupertype_req = 203;
-            Type.SetSupertype.Req type_setSupertype_req = 204;
-
-            // Rule method requests
-            Rule.When.Req rule_when_req = 300;
-            Rule.Then.Req rule_then_req = 301;
+            Type.Delete.Req type_delete_req = 100;
+            Type.SetLabel.Req type_setLabel_req = 101;
+            Type.IsAbstract.Req type_isAbstract_req = 102;
+            Type.GetSupertype.Req type_getSupertype_req = 103;
+            Type.SetSupertype.Req type_setSupertype_req = 104;
 
             // RoleType method requests
-            RoleType.GetRelation.Req roleType_getRelation_req = 400;
+            RoleType.GetRelation.Req roleType_getRelation_req = 200;
 
             // ThingType method requests
-            ThingType.SetAbstract.Req thingType_setAbstract_req = 501;
-            ThingType.UnsetAbstract.Req thingType_unsetAbstract_req = 502;
-            ThingType.SetOwns.Req thingType_setOwns_req = 506;
-            ThingType.SetPlays.Req thingType_setPlays_req = 508;
-            ThingType.UnsetOwns.Req thingType_unsetOwns_req = 509;
-            ThingType.UnsetPlays.Req thingType_unsetPlays_req = 511;
+            ThingType.SetAbstract.Req thingType_setAbstract_req = 300;
+            ThingType.UnsetAbstract.Req thingType_unsetAbstract_req = 301;
+            ThingType.SetOwns.Req thingType_setOwns_req = 302;
+            ThingType.UnsetOwns.Req thingType_unsetOwns_req = 303;
+            ThingType.SetPlays.Req thingType_setPlays_req = 304;
+            ThingType.UnsetPlays.Req thingType_unsetPlays_req = 305;
 
             // EntityType method requests
-            EntityType.Create.Req entityType_create_req = 600;
+            EntityType.Create.Req entityType_create_req = 400;
 
             // RelationType method requests
-            RelationType.Create.Req relationType_create_req = 700;
-            RelationType.GetRelatesForRoleLabel.Req relationType_getRelatesForRoleLabel_req = 701;
-            RelationType.SetRelates.Req relationType_setRelates_req = 702;
-            RelationType.UnsetRelates.Req relationType_unsetRelates_req = 703;
+            RelationType.Create.Req relationType_create_req = 500;
+            RelationType.GetRelatesForRoleLabel.Req relationType_getRelatesForRoleLabel_req = 501;
+            RelationType.SetRelates.Req relationType_setRelates_req = 502;
+            RelationType.UnsetRelates.Req relationType_unsetRelates_req = 503;
 
             // AttributeType method requests
-            AttributeType.Put.Req attributeType_put_req = 800;
-            AttributeType.Get.Req attributeType_get_req = 801;
-            AttributeType.GetRegex.Req attributeType_getRegex_req = 802;
-            AttributeType.SetRegex.Req attributeType_setRegex_req = 803;
+            AttributeType.Put.Req attributeType_put_req = 600;
+            AttributeType.Get.Req attributeType_get_req = 601;
+            AttributeType.GetRegex.Req attributeType_getRegex_req = 602;
+            AttributeType.SetRegex.Req attributeType_setRegex_req = 603;
         }
     }
     message Res {
         oneof res {
             // Type method responses
-            Type.Delete.Res type_delete_res = 200;
-            Type.SetLabel.Res type_setLabel_res = 201;
-            Type.IsAbstract.Res type_isAbstract_res = 202;
-            Type.GetSupertype.Res type_getSupertype_res = 203;
-            Type.SetSupertype.Res type_setSupertype_res = 204;
-
-            // Rule method responses
-            Rule.When.Res rule_when_res = 300;
-            Rule.Then.Res rule_then_res = 301;
+            Type.Delete.Res type_delete_res = 100;
+            Type.SetLabel.Res type_setLabel_res = 101;
+            Type.IsAbstract.Res type_isAbstract_res = 102;
+            Type.GetSupertype.Res type_getSupertype_res = 103;
+            Type.SetSupertype.Res type_setSupertype_res = 104;
 
             // RoleType method responses
-            RoleType.GetRelation.Res roleType_getRelation_res = 400;
+            RoleType.GetRelation.Res roleType_getRelation_res = 200;
 
             // ThingType method responses
-            ThingType.SetAbstract.Res thingType_setAbstract_res = 501;
-            ThingType.UnsetAbstract.Res thingType_unsetAbstract_res = 502;
-            ThingType.SetOwns.Res thingType_setOwns_res = 506;
-            ThingType.SetPlays.Res thingType_setPlays_res = 508;
-            ThingType.UnsetOwns.Res thingType_unsetOwns_res = 509;
-            ThingType.UnsetPlays.Res thingType_unsetPlays_res = 511;
+            ThingType.SetAbstract.Res thingType_setAbstract_res = 300;
+            ThingType.UnsetAbstract.Res thingType_unsetAbstract_res = 301;
+            ThingType.SetOwns.Res thingType_setOwns_res = 302;
+            ThingType.UnsetOwns.Res thingType_unsetOwns_res = 303;
+            ThingType.SetPlays.Res thingType_setPlays_res = 304;
+            ThingType.UnsetPlays.Res thingType_unsetPlays_res = 305;
 
             // EntityType method responses
-            EntityType.Create.Res entityType_create_res = 600;
+            EntityType.Create.Res entityType_create_res = 400;
 
             // RelationType method responses
-            RelationType.Create.Res relationType_create_res = 700;
-            RelationType.GetRelatesForRoleLabel.Res relationType_getRelatesForRoleLabel_res = 701;
-            RelationType.SetRelates.Res relationType_setRelates_res = 702;
-            RelationType.UnsetRelates.Res relationType_unsetRelates_res = 703;
+            RelationType.Create.Res relationType_create_res = 500;
+            RelationType.GetRelatesForRoleLabel.Res relationType_getRelatesForRoleLabel_res = 501;
+            RelationType.SetRelates.Res relationType_setRelates_res = 502;
+            RelationType.UnsetRelates.Res relationType_unsetRelates_res = 503;
 
             // AttributeType method responses
-            AttributeType.Put.Res attributeType_put_res = 800;
-            AttributeType.Get.Res attributeType_get_res = 801;
-            AttributeType.GetRegex.Res attributeType_getRegex_res = 802;
-            AttributeType.SetRegex.Res attributeType_setRegex_res = 803;
+            AttributeType.Put.Res attributeType_put_res = 600;
+            AttributeType.Get.Res attributeType_get_res = 601;
+            AttributeType.GetRegex.Res attributeType_getRegex_res = 602;
+            AttributeType.SetRegex.Res attributeType_setRegex_res = 603;
         }
     }
 
@@ -342,117 +432,46 @@ message TypeMethod {
         message Req {
             oneof req {
                 // Type iterator requests
-                Type.GetSupertypes.Iter.Req type_getSupertypes_iter_req = 205;
-                Type.GetSubtypes.Iter.Req type_getSubtypes_iter_req = 206;
+                Type.GetSupertypes.Iter.Req type_getSupertypes_iter_req = 100;
+                Type.GetSubtypes.Iter.Req type_getSubtypes_iter_req = 101;
 
                 // Role iterator requests
-                RoleType.GetRelations.Iter.Req roleType_getRelations_iter_req = 401;
-                RoleType.GetPlayers.Iter.Req roleType_getPlayers_iter_req = 402;
+                RoleType.GetRelations.Iter.Req roleType_getRelations_iter_req = 200;
+                RoleType.GetPlayers.Iter.Req roleType_getPlayers_iter_req = 201;
 
                 // ThingType iterator requests
-                ThingType.GetInstances.Iter.Req thingType_getInstances_iter_req = 502;
-                ThingType.GetOwns.Iter.Req thingType_getOwns_iter_req = 504;
-                ThingType.GetPlays.Iter.Req thingType_getPlays_iter_req = 505;
+                ThingType.GetInstances.Iter.Req thingType_getInstances_iter_req = 300;
+                ThingType.GetOwns.Iter.Req thingType_getOwns_iter_req = 301;
+                ThingType.GetPlays.Iter.Req thingType_getPlays_iter_req = 302;
 
                 // RelationType iterator requests
-                RelationType.GetRelates.Iter.Req relationType_getRelates_iter_req = 701;
+                RelationType.GetRelates.Iter.Req relationType_getRelates_iter_req = 500;
 
                 // AttributeType iterator requests
-                AttributeType.GetOwners.Iter.Req attributeType_getOwners_iter_req = 800;
+                AttributeType.GetOwners.Iter.Req attributeType_getOwners_iter_req = 600;
             }
         }
 
         message Res {
             oneof res {
                 // Type iterator responses
-                Type.GetSupertypes.Iter.Res type_getSupertypes_iter_res = 205;
-                Type.GetSubtypes.Iter.Res type_getSubtypes_iter_res = 206;
+                Type.GetSupertypes.Iter.Res type_getSupertypes_iter_res = 100;
+                Type.GetSubtypes.Iter.Res type_getSubtypes_iter_res = 101;
 
                 // RoleType iterator responses
-                RoleType.GetRelations.Iter.Res roleType_getRelations_iter_res = 401;
-                RoleType.GetPlayers.Iter.Res roleType_getPlayers_iter_res = 402;
+                RoleType.GetRelations.Iter.Res roleType_getRelations_iter_res = 200;
+                RoleType.GetPlayers.Iter.Res roleType_getPlayers_iter_res = 201;
 
-                // Type iterator responses
-                ThingType.GetInstances.Iter.Res thingType_getInstances_iter_res = 502;
-                ThingType.GetOwns.Iter.Res thingType_getOwns_iter_res = 504;
-                ThingType.GetPlays.Iter.Res thingType_getPlays_iter_res = 505;
+                // Thing type iterator responses
+                ThingType.GetInstances.Iter.Res thingType_getInstances_iter_res = 300;
+                ThingType.GetOwns.Iter.Res thingType_getOwns_iter_res = 301;
+                ThingType.GetPlays.Iter.Res thingType_getPlays_iter_res = 302;
 
                 // RelationType iterator responses
-                RelationType.GetRelates.Iter.Res relationType_getRelates_iter_res = 701;
+                RelationType.GetRelates.Iter.Res relationType_getRelates_iter_res = 500;
 
                 // AttributeType iterator responses
-                AttributeType.GetOwners.Iter.Res attributeType_getOwners_iter_res = 800;
-            }
-        }
-    }
-}
-
-// Type methods
-message Type {
-    string label = 1;
-    string scope = 2;
-    ENCODING encoding = 3;
-    AttributeType.VALUE_TYPE valueType = 4;
-    bool root = 5;
-
-    enum ENCODING {
-        THING_TYPE = 0;
-        ENTITY_TYPE = 1;
-        RELATION_TYPE = 2;
-        ATTRIBUTE_TYPE = 3;
-        ROLE_TYPE = 4;
-        RULE = 5;
-    }
-
-    message Delete {
-        message Req {}
-        message Res {}
-    }
-
-    message SetLabel {
-        message Req {
-            string label = 1;
-        }
-        message Res {}
-    }
-
-    message IsAbstract {
-        message Req {}
-        message Res {
-            bool abstract = 1;
-        }
-    }
-
-    message GetSupertype {
-        message Req {}
-        message Res {
-            oneof res {
-                Type type = 1;
-            }
-        }
-    }
-
-    message SetSupertype {
-        message Req {
-            Type type = 1;
-        }
-        message Res {}
-    }
-
-    message GetSupertypes {
-        message Iter {
-            message Req {}
-            message Res {
-                Type type = 1;
-            }
-        }
-    }
-
-    message GetSubtypes {
-        message Iter {
-            message Req {}
-            message Res {
-                Type type = 1;
+                AttributeType.GetOwners.Iter.Res attributeType_getOwners_iter_res = 600;
             }
         }
     }
@@ -461,27 +480,22 @@ message Type {
 
 // Rule methods
 
-message Rule {
-
-    message When {
-        message Req {}
-        message Res {
-            oneof res {
-                string pattern = 1;
-            }
+message RuleMethod {
+    message Req {
+        oneof req {
+            // Rule method requests
+            Rule.When.Req rule_when_req = 100;
+            Rule.Then.Req rule_then_req = 101;
         }
     }
-
-    message Then {
-        message Req {}
-        message Res {
-            oneof res {
-                string pattern = 1;
-            }
+    message Res {
+        oneof res {
+            // Rule method responses
+            Rule.When.Res rule_when_res = 100;
+            Rule.Then.Res rule_then_res = 101;
         }
     }
 }
-
 
 // RoleType methods
 

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -484,15 +484,15 @@ message RuleMethod {
     message Req {
         oneof req {
             // Rule method requests
-            Rule.When.Req rule_when_req = 100;
-            Rule.Then.Req rule_then_req = 101;
+            Rule.When.Req rule_getwhen_req = 100;
+            Rule.Then.Req rule_getthen_req = 101;
         }
     }
     message Res {
         oneof res {
             // Rule method responses
-            Rule.When.Res rule_when_res = 100;
-            Rule.Then.Res rule_then_res = 101;
+            Rule.When.Res rule_getwhen_res = 100;
+            Rule.Then.Res rule_getthen_res = 101;
         }
     }
 }

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -110,7 +110,14 @@ message Rule {
     string when = 2;
     string then = 3;
 
-    message When {
+    message SetWhen {
+        message Req {
+            string pattern = 1;
+        }
+        message Res {}
+    }
+
+    message GetWhen {
         message Req {}
         message Res {
             oneof res {
@@ -119,7 +126,17 @@ message Rule {
         }
     }
 
-    message Then {
+    message SetThen {
+        message Req {
+            string pattern = 1;
+        }
+        message Res {
+            oneof res {
+            }
+        }
+    }
+
+    message GetThen {
         message Req {}
         message Res {
             oneof res {
@@ -276,8 +293,6 @@ message ThingMethod {
         }
     }
 }
-
-
 
 
 // Relation methods
@@ -496,6 +511,7 @@ message RuleMethod {
         }
     }
 }
+
 
 // RoleType methods
 

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -216,29 +216,29 @@ message ThingMethod {
     message Req {
         oneof req {
             // Thing method requests
-            Thing.Delete.Req thing_delete_req = 900;
-            Thing.GetType.Req thing_getType_req = 901;
-            Thing.IsInferred.Req thing_isInferred_req = 902;
-            Thing.SetHas.Req thing_setHas_req = 906;
-            Thing.UnsetHas.Req thing_unsetHas_req = 907;
+            Thing.Delete.Req thing_delete_req = 100;
+            Thing.GetType.Req thing_getType_req = 101;
+            Thing.IsInferred.Req thing_isInferred_req = 102;
+            Thing.SetHas.Req thing_setHas_req = 106;
+            Thing.UnsetHas.Req thing_unsetHas_req = 107;
 
             // Relation method requests
-            Relation.AddPlayer.Req relation_addPlayer_req = 1002;
-            Relation.RemovePlayer.Req relation_removePlayer_req = 1003;
+            Relation.AddPlayer.Req relation_addPlayer_req = 200;
+            Relation.RemovePlayer.Req relation_removePlayer_req = 201;
         }
     }
     message Res {
         oneof res {
             // Thing method responses
-            Thing.Delete.Res thing_delete_res = 900;
-            Thing.GetType.Res thing_getType_res = 901;
-            Thing.IsInferred.Res thing_isInferred_res = 902;
-            Thing.SetHas.Res thing_setHas_res = 906;
-            Thing.UnsetHas.Res thing_unsetHas_res = 907;
+            Thing.Delete.Res thing_delete_res = 100;
+            Thing.GetType.Res thing_getType_res = 101;
+            Thing.IsInferred.Res thing_isInferred_res = 102;
+            Thing.SetHas.Res thing_setHas_res = 103;
+            Thing.UnsetHas.Res thing_unsetHas_res = 104;
 
             // Relation method responses
-            Relation.AddPlayer.Res relation_addPlayer_res = 1002;
-            Relation.RemovePlayer.Res relation_removePlayer_res = 1003;
+            Relation.AddPlayer.Res relation_addPlayer_res = 200;
+            Relation.RemovePlayer.Res relation_removePlayer_res = 201;
         }
     }
 
@@ -246,32 +246,32 @@ message ThingMethod {
         message Req {
             oneof req {
                 // Thing iterator requests
-                Thing.GetHas.Iter.Req thing_getHas_iter_req = 903;
-                Thing.GetRelations.Iter.Req thing_getRelations_iter_req = 904;
-                Thing.GetPlays.Iter.Req thing_getPlays_iter_req = 905;
+                Thing.GetHas.Iter.Req thing_getHas_iter_req = 100;
+                Thing.GetRelations.Iter.Req thing_getRelations_iter_req = 101;
+                Thing.GetPlays.Iter.Req thing_getPlays_iter_req = 102;
 
                 // Relation iterator responses
-                Relation.GetPlayers.Iter.Req relation_getPlayers_iter_req = 1000;
-                Relation.GetPlayersByRoleType.Iter.Req relation_getPlayersByRoleType_iter_req = 1001;
+                Relation.GetPlayers.Iter.Req relation_getPlayers_iter_req = 200;
+                Relation.GetPlayersByRoleType.Iter.Req relation_getPlayersByRoleType_iter_req = 201;
 
                 // Attribute iterator requests
-                Attribute.GetOwners.Iter.Req attribute_getOwners_iter_req = 1101;
+                Attribute.GetOwners.Iter.Req attribute_getOwners_iter_req = 302;
             }
         }
 
         message Res {
             oneof res {
                 // Thing iterator responses
-                Thing.GetHas.Iter.Res thing_getHas_iter_res = 903;
-                Thing.GetRelations.Iter.Res thing_getRelations_iter_res = 904;
-                Thing.GetPlays.Iter.Res thing_getPlays_iter_res = 905;
+                Thing.GetHas.Iter.Res thing_getHas_iter_res = 100;
+                Thing.GetRelations.Iter.Res thing_getRelations_iter_res = 101;
+                Thing.GetPlays.Iter.Res thing_getPlays_iter_res = 102;
 
                 // Relation iterator responses
-                Relation.GetPlayers.Iter.Res relation_getPlayers_iter_res = 1000;
-                Relation.GetPlayersByRoleType.Iter.Res relation_getPlayersByRoleType_iter_res = 1001;
+                Relation.GetPlayers.Iter.Res relation_getPlayers_iter_res = 200;
+                Relation.GetPlayersByRoleType.Iter.Res relation_getPlayersByRoleType_iter_res = 201;
 
                 // Attribute iterator responses
-                Attribute.GetOwners.Iter.Res attribute_getOwners_iter_res = 1101;
+                Attribute.GetOwners.Iter.Res attribute_getOwners_iter_res = 300;
             }
         }
     }

--- a/protobuf/transaction.proto
+++ b/protobuf/transaction.proto
@@ -174,7 +174,7 @@ message Transaction {
             string then = 3;
         }
         message Res {
-            grakn.protocol.Type rule = 1;
+            grakn.protocol.Rule rule = 1;
         }
     }
 
@@ -217,6 +217,16 @@ message Transaction {
                 message Res {
                     TypeMethod.Iter.Res response = 1;
                 }
+            }
+        }
+
+        message Rule {
+            message Req {
+                string label = 1;
+                RuleMethod.Req method = 2;
+            }
+            message Res {
+                RuleMethod.Res response = 1;
             }
         }
     }

--- a/protobuf/transaction.proto
+++ b/protobuf/transaction.proto
@@ -42,7 +42,7 @@ message Transaction {
             PutRule.Req putRule_req = 12;
             ConceptMethod.Thing.Req conceptMethod_thing_req = 13;
             ConceptMethod.Type.Req conceptMethod_type_req = 14;
-            RuleMethod.Req ruleMethod_req = 15;
+            ConceptMethod.Rule.Req ruleMethod_req = 15;
             Explanation.Req explanation_req = 16;
         }
     }
@@ -60,7 +60,7 @@ message Transaction {
             PutRule.Res putRule_res = 12;
             ConceptMethod.Thing.Res conceptMethod_thing_res = 13;
             ConceptMethod.Type.Res conceptMethod_type_res = 14;
-            RuleMethod.Req ruleMethod_res = 15;
+            ConceptMethod.Rule.Res ruleMethod_res = 15;
             Explanation.Res explanation_res = 16;
         }
     }

--- a/protobuf/transaction.proto
+++ b/protobuf/transaction.proto
@@ -42,7 +42,8 @@ message Transaction {
             PutRule.Req putRule_req = 12;
             ConceptMethod.Thing.Req conceptMethod_thing_req = 13;
             ConceptMethod.Type.Req conceptMethod_type_req = 14;
-            Explanation.Req explanation_req = 15;
+            RuleMethod.Req ruleMethod_req = 15;
+            Explanation.Req explanation_req = 16;
         }
     }
 
@@ -59,7 +60,8 @@ message Transaction {
             PutRule.Res putRule_res = 12;
             ConceptMethod.Thing.Res conceptMethod_thing_res = 13;
             ConceptMethod.Type.Res conceptMethod_type_res = 14;
-            Explanation.Res explanation_res = 15;
+            RuleMethod.Req ruleMethod_res = 15;
+            Explanation.Res explanation_res = 16;
         }
     }
 


### PR DESCRIPTION
## What is the goal of this PR?
We split rules from conceptually being a Type in the protocol. They are still viewed as part of the world of "Concepts" in grakn, but as separate elements of the schema, only having a label in common with types.

## What are the changes implemented in this PR?
* Split `Rule` from being part of `Type`
* rearrange `concept.proto` to group the `Concept` definitions at the top, specialised messages below
* compact and clean up numbering ranges of messages - won't affect us (breaking backwards compat anyway) 