### PR TITLE
Fixed implementation of Rule and RuleMethod in Concept.proto

### DIFF
--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -130,10 +130,7 @@ message Rule {
         message Req {
             string pattern = 1;
         }
-        message Res {
-            oneof res {
-            }
-        }
+        message Res {}
     }
 
     message GetThen {
@@ -236,8 +233,8 @@ message ThingMethod {
             Thing.Delete.Req thing_delete_req = 100;
             Thing.GetType.Req thing_getType_req = 101;
             Thing.IsInferred.Req thing_isInferred_req = 102;
-            Thing.SetHas.Req thing_setHas_req = 106;
-            Thing.UnsetHas.Req thing_unsetHas_req = 107;
+            Thing.SetHas.Req thing_setHas_req = 103;
+            Thing.UnsetHas.Req thing_unsetHas_req = 104;
 
             // Relation method requests
             Relation.AddPlayer.Req relation_addPlayer_req = 200;
@@ -499,15 +496,19 @@ message RuleMethod {
     message Req {
         oneof req {
             // Rule method requests
-            Rule.When.Req rule_getwhen_req = 100;
-            Rule.Then.Req rule_getthen_req = 101;
+            Rule.GetWhen.Req rule_getWhen_req = 100;
+            Rule.GetThen.Req rule_getThen_req = 101;
+            Rule.SetWhen.Req rule_setWhen_req = 102;
+            Rule.SetThen.Req rule_setThen_req = 103;
         }
     }
     message Res {
         oneof res {
             // Rule method responses
-            Rule.When.Res rule_getwhen_res = 100;
-            Rule.Then.Res rule_getthen_res = 101;
+            Rule.GetWhen.Res rule_getWhen_res = 100;
+            Rule.GetThen.Res rule_getThen_res = 101;
+            Rule.SetWhen.Res rule_setWhen_res = 102;
+            Rule.SetThen.Res rule_setThen_res = 103;
         }
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

I think you were rushing in implementing `Rule` and `RuleMethod` in `Concept.proto` in PR #64, @flyingsilverfin :) and without enabling CI, you didn't realise that the protocol wasn't building at all.


## What are the changes implemented in this PR?

1) `Rule.SetThen.Res` was not correctly defined: it had an empty `oneof`, which is not a valid syntax.
2) `RuleMethod` was referring to messages that did not exist: `Rule.When` and `Rule.Then` did not exist.
3) `RuleMethod` needed 4 messages each for `req` and `res`: `GetWhen`, `GetThen`, `SetWhen`, and `SetThen` (in that order).
4) `RuleMethod` variable names were not camelCase.

Additionally,
1) `ThingMethod.Req` had a cleanup of message IDs, but some numbers were not properly compacted.

The PR #64 also to reorder the declaration of messages in this file. However, it's partially complete. Notice how under `RuleMethod` there are more message definitions of the subclasses  of `Type`, which presumably was thought be placed at the top of the file with the moving of the `Type` message itself to the very top. I'll fix this in a subsequent PR.