### PR TITLE
Create the new Query API

### DIFF
--- a/grpc/java/BUILD
+++ b/grpc/java/BUILD
@@ -30,6 +30,7 @@ java_grpc_compile(
         "//protobuf:session-proto",
         "//protobuf:transaction-proto",
         "//protobuf:answer-proto",
+        "//protobuf:query-proto",
         "//protobuf:concept-proto",
         "//protobuf:options-proto",
     ]

--- a/grpc/nodejs/BUILD
+++ b/grpc/nodejs/BUILD
@@ -25,6 +25,7 @@ node_grpc_compile(
         "//protobuf:database-proto",
         "//protobuf:session-proto",
         "//protobuf:transaction-proto",
+        "//protobuf:query-proto",
         "//protobuf:concept-proto",
         "//protobuf:answer-proto",
     ]

--- a/grpc/python/BUILD
+++ b/grpc/python/BUILD
@@ -26,6 +26,7 @@ python_grpc_compile(
         "//protobuf:database-proto",
         "//protobuf:session-proto",
         "//protobuf:transaction-proto",
+        "//protobuf:query-proto",
         "//protobuf:concept-proto",
         "//protobuf:answer-proto",
     ],

--- a/protobuf/BUILD
+++ b/protobuf/BUILD
@@ -44,8 +44,19 @@ proto_library(
     deps = [
         ":answer-proto",
         ":concept-proto",
-        ":options-proto"
+        ":options-proto",
+        ":query-proto",
     ]
+)
+
+proto_library(
+    name = "query-proto",
+    srcs = ["query.proto"],
+    deps = [
+        ":answer-proto",
+        ":concept-proto",
+        ":options-proto",
+    ],
 )
 
 proto_library(

--- a/protobuf/answer.proto
+++ b/protobuf/answer.proto
@@ -28,21 +28,7 @@ message Answer {
     oneof answer {
         AnswerGroup answerGroup = 1;
         ConceptMap conceptMap = 2;
-        ConceptList conceptList = 3;
-        ConceptSet conceptSet = 4;
-        ConceptSetMeasure conceptSetMeasure = 5;
-        Value value = 6;
-        Void void = 7;
-    }
-}
-
-message Explanation {
-    message Req {
-        ConceptMap explainable = 1;
-    }
-    message Res {
-        repeated ConceptMap explanation = 1;
-        Type rule = 2;
+        Number number = 3;
     }
 }
 
@@ -55,27 +41,6 @@ message ConceptMap {
     map<string, Concept> map = 1;
     string pattern = 2;
     bool hasExplanation = 3;
-}
-
-message ConceptList {
-    repeated bytes iids = 1;
-}
-
-message ConceptSet {
-    repeated bytes iids = 1;
-}
-
-message ConceptSetMeasure {
-    repeated bytes iids = 1;
-    Number measurement = 2;
-}
-
-message Value {
-    Number number = 1;
-}
-
-message Void {
-    string message = 1;
 }
 
 message Number {

--- a/protobuf/answer.proto
+++ b/protobuf/answer.proto
@@ -40,7 +40,6 @@ message AnswerGroup {
 message ConceptMap {
     map<string, Concept> map = 1;
     string pattern = 2;
-    bool hasExplanation = 3;
 }
 
 message Number {

--- a/protobuf/query.proto
+++ b/protobuf/query.proto
@@ -29,6 +29,7 @@ package grakn.protocol;
 message Query {
 
     message Req {
+        Options options = 1;
         oneof req {
             Graql.Delete.Req delete_req = 100;
             Graql.Define.Req define_req = 101;
@@ -46,6 +47,7 @@ message Query {
 
     message Iter {
         message Req {
+            Options options = 1;
             oneof req {
                 Graql.Match.Iter.Req match_iter_req = 100;
                 Graql.Insert.Iter.Req insert_iter_req = 101;
@@ -66,7 +68,6 @@ message Graql {
         message Iter {
             message Req {
                 string query = 1;
-                Options options = 2;
             }
             message Res {
                 ConceptMap answer = 1;
@@ -78,7 +79,6 @@ message Graql {
         message Iter {
             message Req {
                 string query = 1;
-                Options options = 2;
             }
             message Res {
                 ConceptMap answer = 1;
@@ -89,7 +89,6 @@ message Graql {
     message Delete {
         message Req {
             string query = 1;
-            Options options = 2;
         }
         message Res {}
     }
@@ -97,7 +96,6 @@ message Graql {
     message Define {
         message Req {
             string query = 1;
-            Options options = 2;
         }
         message Res {
             repeated Type thingType = 1;
@@ -107,7 +105,6 @@ message Graql {
     message Undefine {
         message Req {
             string query = 1;
-            Options options = 2;
         }
         message Res {}
     }

--- a/protobuf/query.proto
+++ b/protobuf/query.proto
@@ -29,7 +29,8 @@ package grakn.protocol;
 message Query {
 
     message Req {
-        Options options = 1;
+        string query = 1;
+        Options options = 2;
         oneof req {
             Graql.Delete.Req delete_req = 100;
             Graql.Define.Req define_req = 101;
@@ -47,7 +48,8 @@ message Query {
 
     message Iter {
         message Req {
-            Options options = 1;
+            string query = 1;
+            Options options = 2;
             oneof req {
                 Graql.Match.Iter.Req match_iter_req = 100;
                 Graql.Insert.Iter.Req insert_iter_req = 101;
@@ -66,9 +68,7 @@ message Graql {
 
     message Match {
         message Iter {
-            message Req {
-                string query = 1;
-            }
+            message Req {}
             message Res {
                 ConceptMap answer = 1;
             }
@@ -77,9 +77,7 @@ message Graql {
 
     message Insert {
         message Iter {
-            message Req {
-                string query = 1;
-            }
+            message Req {}
             message Res {
                 ConceptMap answer = 1;
             }
@@ -87,25 +85,19 @@ message Graql {
     }
 
     message Delete {
-        message Req {
-            string query = 1;
-        }
+        message Req {}
         message Res {}
     }
 
     message Define {
-        message Req {
-            string query = 1;
-        }
+        message Req {}
         message Res {
             repeated Type thingType = 1;
         }
     }
 
     message Undefine {
-        message Req {
-            string query = 1;
-        }
+        message Req {}
         message Res {}
     }
 }

--- a/protobuf/query.proto
+++ b/protobuf/query.proto
@@ -1,0 +1,111 @@
+//
+// Copyright (C) 2020 Grakn Labs
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+syntax = "proto3";
+
+option java_package = "grakn.protocol";
+option java_outer_classname = "QueryProto";
+
+import "protobuf/answer.proto";
+import "protobuf/concept.proto";
+import "protobuf/options.proto";
+
+package grakn.protocol;
+
+message Query {
+
+    message Req {
+        Options options = 1;
+        oneof req {
+            Graql.Delete.Req delete_req = 100;
+            Graql.Define.Req define_req = 101;
+            Graql.Undefine.Req undefine_req = 102;
+        }
+    }
+
+    message Res {
+        oneof res {
+            Graql.Delete.Res delete_res = 100;
+            Graql.Define.Res define_res = 101;
+            Graql.Undefine.Res undefine_res = 102;
+        }
+    }
+
+    message Iter {
+        message Req {
+            Options options = 1;
+            oneof req {
+                Graql.Match.Iter.Req match_iter_req = 100;
+                Graql.Insert.Iter.Req insert_iter_req = 101;
+            }
+        }
+        message Res {
+            oneof res {
+                Graql.Match.Iter.Res match_iter_res = 100;
+                Graql.Insert.Iter.Res insert_iter_res = 101;
+            }
+        }
+    }
+}
+
+message Graql {
+
+    message Match {
+        message Iter {
+            message Req {
+                string query = 1;
+            }
+            message Res {
+                ConceptMap answer = 1;
+            }
+        }
+    }
+
+    message Insert {
+        message Iter {
+            message Req {
+                string query = 1;
+            }
+            message Res {
+                ConceptMap answer = 1;
+            }
+        }
+    }
+
+    message Delete {
+        message Req {
+            string query = 1;
+        }
+        message Res {}
+    }
+
+    message Define {
+        message Req {
+            string query = 1;
+        }
+        message Res {
+            repeated Type thingType = 1;
+        }
+    }
+
+    message Undefine {
+        message Req {
+            string query = 1;
+        }
+        message Res {}
+    }
+}

--- a/protobuf/query.proto
+++ b/protobuf/query.proto
@@ -29,7 +29,6 @@ package grakn.protocol;
 message Query {
 
     message Req {
-        Options options = 1;
         oneof req {
             Graql.Delete.Req delete_req = 100;
             Graql.Define.Req define_req = 101;
@@ -47,7 +46,6 @@ message Query {
 
     message Iter {
         message Req {
-            Options options = 1;
             oneof req {
                 Graql.Match.Iter.Req match_iter_req = 100;
                 Graql.Insert.Iter.Req insert_iter_req = 101;
@@ -68,6 +66,7 @@ message Graql {
         message Iter {
             message Req {
                 string query = 1;
+                Options options = 2;
             }
             message Res {
                 ConceptMap answer = 1;
@@ -79,6 +78,7 @@ message Graql {
         message Iter {
             message Req {
                 string query = 1;
+                Options options = 2;
             }
             message Res {
                 ConceptMap answer = 1;
@@ -89,6 +89,7 @@ message Graql {
     message Delete {
         message Req {
             string query = 1;
+            Options options = 2;
         }
         message Res {}
     }
@@ -96,6 +97,7 @@ message Graql {
     message Define {
         message Req {
             string query = 1;
+            Options options = 2;
         }
         message Res {
             repeated Type thingType = 1;
@@ -105,6 +107,7 @@ message Graql {
     message Undefine {
         message Req {
             string query = 1;
+            Options options = 2;
         }
         message Res {}
     }

--- a/protobuf/query.proto
+++ b/protobuf/query.proto
@@ -29,8 +29,7 @@ package grakn.protocol;
 message Query {
 
     message Req {
-        string query = 1;
-        Options options = 2;
+        Options options = 1;
         oneof req {
             Graql.Delete.Req delete_req = 100;
             Graql.Define.Req define_req = 101;
@@ -48,8 +47,7 @@ message Query {
 
     message Iter {
         message Req {
-            string query = 1;
-            Options options = 2;
+            Options options = 1;
             oneof req {
                 Graql.Match.Iter.Req match_iter_req = 100;
                 Graql.Insert.Iter.Req insert_iter_req = 101;
@@ -68,7 +66,9 @@ message Graql {
 
     message Match {
         message Iter {
-            message Req {}
+            message Req {
+                string query = 1;
+            }
             message Res {
                 ConceptMap answer = 1;
             }
@@ -77,7 +77,9 @@ message Graql {
 
     message Insert {
         message Iter {
-            message Req {}
+            message Req {
+                string query = 1;
+            }
             message Res {
                 ConceptMap answer = 1;
             }
@@ -85,19 +87,25 @@ message Graql {
     }
 
     message Delete {
-        message Req {}
+        message Req {
+            string query = 1;
+        }
         message Res {}
     }
 
     message Define {
-        message Req {}
+        message Req {
+            string query = 1;
+        }
         message Res {
             repeated Type thingType = 1;
         }
     }
 
     message Undefine {
-        message Req {}
+        message Req {
+            string query = 1;
+        }
         message Res {}
     }
 }

--- a/protobuf/transaction.proto
+++ b/protobuf/transaction.proto
@@ -33,14 +33,15 @@ message Transaction {
         oneof req {
             Open.Req open_req = 1;
             Commit.Req commit_req = 2;
-            Iter.Req iter_req = 3;
-            Query.Req query_req = 4;
-            GetType.Req getType_req = 5;
-            GetThing.Req getThing_req = 6;
-            GetRule.Req getRule_req = 7;
-            PutEntityType.Req putEntityType_req = 8;
-            PutAttributeType.Req putAttributeType_req = 9;
-            PutRelationType.Req putRelationType_req = 10;
+            Rollback.Req rollback_req = 3;
+            Iter.Req iter_req = 4;
+            Query.Req query_req = 5;
+            GetType.Req getType_req = 6;
+            GetThing.Req getThing_req = 7;
+            GetRule.Req getRule_req = 8;
+            PutEntityType.Req putEntityType_req = 9;
+            PutAttributeType.Req putAttributeType_req = 10;
+            PutRelationType.Req putRelationType_req = 11;
             PutRule.Req putRule_req = 12;
             ThingMethod.Req thingMethod_req = 13;
             TypeMethod.Req typeMethod_req = 14;
@@ -53,14 +54,15 @@ message Transaction {
         oneof res {
             Open.Res open_res = 1;
             Commit.Res commit_res = 2;
-            Iter.Res iter_res = 3;
-            Query.Res query_res = 4;
-            GetType.Res getType_res = 5;
-            GetThing.Res getThing_res = 6;
-            GetRule.Res getRule_res = 7;
-            PutEntityType.Res putEntityType_res = 8;
-            PutAttributeType.Res putAttributeType_res = 9;
-            PutRelationType.Res putRelationType_res = 10;
+            Rollback.Res rollback_res = 3;
+            Iter.Res iter_res = 4;
+            Query.Res query_res = 5;
+            GetType.Res getType_res = 6;
+            GetThing.Res getThing_res = 7;
+            GetRule.Res getRule_res = 8;
+            PutEntityType.Res putEntityType_res = 9;
+            PutAttributeType.Res putAttributeType_res = 10;
+            PutRelationType.Res putRelationType_res = 11;
             PutRule.Res putRule_res = 12;
             ThingMethod.Res thingMethod_res = 13;
             TypeMethod.Res typeMethod_res = 14;
@@ -104,6 +106,11 @@ message Transaction {
     }
 
     message Commit {
+        message Req {}
+        message Res {}
+    }
+
+    message Rollback {
         message Req {}
         message Res {}
     }

--- a/protobuf/transaction.proto
+++ b/protobuf/transaction.proto
@@ -20,9 +20,9 @@ syntax = "proto3";
 option java_package = "grakn.protocol";
 option java_outer_classname = "TransactionProto";
 
-import "protobuf/answer.proto";
 import "protobuf/concept.proto";
 import "protobuf/options.proto";
+import "protobuf/query.proto";
 
 package grakn.protocol;
 
@@ -33,7 +33,8 @@ message Transaction {
         oneof req {
             Open.Req open_req = 1;
             Commit.Req commit_req = 2;
-            Iter.Req iter_req = 4;
+            Iter.Req iter_req = 3;
+            Query.Req query_req = 4;
             GetType.Req getType_req = 5;
             GetThing.Req getThing_req = 6;
             GetRule.Req getRule_req = 7;
@@ -44,7 +45,7 @@ message Transaction {
             ThingMethod.Req thingMethod_req = 13;
             TypeMethod.Req typeMethod_req = 14;
             RuleMethod.Req ruleMethod_req = 15;
-            Explanation.Req explanation_req = 16;
+            //Explanation.Req explanation_req = 16;
         }
     }
 
@@ -52,7 +53,8 @@ message Transaction {
         oneof res {
             Open.Res open_res = 1;
             Commit.Res commit_res = 2;
-            Iter.Res iter_res = 4;
+            Iter.Res iter_res = 3;
+            Query.Res query_res = 4;
             GetType.Res getType_res = 5;
             GetThing.Res getThing_res = 6;
             GetRule.Res getRule_res = 7;
@@ -63,7 +65,7 @@ message Transaction {
             ThingMethod.Res thingMethod_res = 13;
             TypeMethod.Res typeMethod_res = 14;
             RuleMethod.Res ruleMethod_res = 15;
-            Explanation.Res explanation_res = 16;
+            //Explanation.Res explanation_res = 16;
         }
     }
 
@@ -104,18 +106,6 @@ message Transaction {
     message Commit {
         message Req {}
         message Res {}
-    }
-
-    message Query {
-        message Iter {
-            message Req {
-                string query = 1;
-                Options options = 2;
-            }
-            message Res {
-                Answer answer = 1;
-            }
-        }
     }
 
     message GetType {


### PR DESCRIPTION
## What is the goal of this PR?

To provide protocol messages that fit all the needs of our new Query API 2.0 - specifically Graql Match, Define, Undefine, Insert and Delete, while thinking about forwards compatibility.

## What are the changes implemented in this PR?

Added QueryProto, a new protobuf file that contains two new messages: Query, and Graql.

Query is designed to mimic the structure of Concept; it contains Req, Res, Iter.Req and Iter.Res, which each come in pairs and choose from the various Graql methods available.

The Graql methods are encapsulated in a new message named Graql. Graql contains Match, Define, Undefine, Insert and Delete. These are the possible methods to choose from when constructing a Query.

This is a significant change from our previous structure, where all Graql queries had the same type, and were thus forced to also return the same type - which meant we had an awkward Answer object that could contain all sorts of things. Now, each query request has its own dedicated response type - for example, 'repeated Type' for Define, 'ConceptMap' for Match.Iter, and nothing for Delete.

This Answer object does still exist, purely because of AnswerGroup - whose structure is yet to be fleshed out - but it has been slimmed down substantially; only ConceptMap, AnswerGroup and Number remain as possible types of Answers. Number is not currently used, but it will be used in the future for Aggregates. We've also deleted Explanation while we determine how it will look in 2.0.