### PR TITLE
Defines return nothing, Rules have no setters

### DIFF
--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -218,16 +218,12 @@ message RuleMethod {
         oneof req {
             Rule.Delete.Req rule_delete_req = 100;
             Rule.SetLabel.Req rule_setLabel_req = 101;
-            Rule.SetWhen.Req rule_setWhen_req = 102;
-            Rule.SetThen.Req rule_setThen_req = 103;
         }
     }
     message Res {
         oneof res {
             Rule.Delete.Res rule_delete_res = 100;
             Rule.SetLabel.Res rule_setLabel_res = 101;
-            Rule.SetWhen.Res rule_setWhen_res = 102;
-            Rule.SetThen.Res rule_setThen_res = 103;
         }
     }
 }

--- a/protobuf/query.proto
+++ b/protobuf/query.proto
@@ -97,9 +97,7 @@ message Graql {
         message Req {
             string query = 1;
         }
-        message Res {
-            repeated Type thingType = 1;
-        }
+        message Res {}
     }
 
     message Undefine {


### PR DESCRIPTION
## What is the goal of this PR?
Rules can no longer set a `when` or `then`, and `define` queries no longer return anything.

## What are the changes implemented in this PR?
* Remove `setWhen` and `setThen` messages in `RuleMethod`
* `Define` queries have no return data