### PR TITLE
Allow multiple answers batched within one grpc message 

### DIFF
--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -226,7 +226,6 @@ message Thing {
             repeated Type attribute_types = 1;
             bool keys_only = 2;
         }
-        // @Iterable
         message Res {
             repeated Thing attribute = 1;
         }
@@ -234,7 +233,6 @@ message Thing {
 
     message GetPlays {
         message Req {}
-        // @Iterable
         message Res {
             repeated Type role_type = 1;
         }
@@ -244,7 +242,6 @@ message Thing {
         message Req {
             repeated Type role_types = 1;
         }
-        // @Iterable
         message Res {
             repeated Thing relation = 1;
         }
@@ -257,7 +254,6 @@ message Relation {
         message Req {
             repeated Type role_types = 1;
         }
-        // @Iterable
         message Res {
             repeated Thing thing = 1;
         }
@@ -269,7 +265,6 @@ message Relation {
             Thing player = 2;
         }
         message Req {}
-        // @Iterable
         message Res {
             repeated RoleTypeWithPlayer role_type_with_player = 1;
         }
@@ -300,7 +295,6 @@ message Attribute {
                 Type thing_type = 1;
             }
         }
-        // @Iterable
         message Res {
             repeated Thing thing = 1;
         }
@@ -463,7 +457,6 @@ message Type {
 
     message GetSupertypes {
         message Req {}
-        // @Iterable
         message Res {
             repeated Type type = 1;
         }
@@ -471,7 +464,6 @@ message Type {
 
     message GetSubtypes {
         message Req {}
-        // @Iterable
         message Res {
             repeated Type type = 1;
         }
@@ -491,7 +483,6 @@ message RoleType {
 
     message GetRelationTypes {
         message Req {}
-        // @Iterable
         message Res {
             repeated Type relationType = 1;
         }
@@ -499,7 +490,6 @@ message RoleType {
 
     message GetPlayers {
         message Req {}
-        // @Iterable
         message Res {
             repeated Type thingType = 1;
         }
@@ -522,7 +512,6 @@ message ThingType {
 
     message GetInstances {
         message Req {}
-        // @Iterable
         message Res {
             repeated Thing thing = 1;
         }
@@ -535,7 +524,6 @@ message ThingType {
             }
             bool keys_only = 3;
         }
-        // @Iterable
         message Res {
             repeated Type attribute_type = 1;
         }
@@ -543,7 +531,6 @@ message ThingType {
 
     message GetPlays {
         message Req {}
-        // @Iterable
         message Res {
             repeated Type role = 1;
         }
@@ -610,7 +597,6 @@ message RelationType {
 
     message GetRelates {
         message Req {}
-        // @Iterable
         message Res {
             repeated Type role = 1;
         }
@@ -682,7 +668,6 @@ message AttributeType {
         message Req {
             bool onlyKey = 1;
         }
-        // @Iterable
         message Res {
             repeated Type owner = 1;
         }
@@ -708,7 +693,6 @@ message AttributeType {
                 VALUE_TYPE value_type = 1;
             }
         }
-        // @Iterable
         message Res {
             repeated Type type = 1;
         }
@@ -720,7 +704,6 @@ message AttributeType {
                 VALUE_TYPE value_type = 1;
             }
         }
-        // @Iterable
         message Res {
             repeated Thing thing = 1;
         }

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -521,7 +521,7 @@ message ThingType {
         message Req {}
         // @Iterable
         message Res {
-            Thing thing = 1;
+            repeated Thing thing = 1;
         }
     }
 

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -228,7 +228,7 @@ message Thing {
         }
         // @Iterable
         message Res {
-            Thing attribute = 1;
+            repeated Thing attribute = 1;
         }
     }
 
@@ -236,7 +236,7 @@ message Thing {
         message Req {}
         // @Iterable
         message Res {
-            Type role_type = 1;
+            repeated Type role_type = 1;
         }
     }
 
@@ -246,7 +246,7 @@ message Thing {
         }
         // @Iterable
         message Res {
-            Thing relation = 1;
+            repeated Thing relation = 1;
         }
     }
 }
@@ -259,16 +259,19 @@ message Relation {
         }
         // @Iterable
         message Res {
-            Thing thing = 1;
+            repeated Thing thing = 1;
         }
     }
 
     message GetPlayersByRoleType {
+        message RoleTypeWithPlayer {
+            Type role_type = 1;
+            Thing player = 2;
+        }
         message Req {}
         // @Iterable
         message Res {
-            Type role_type = 1;
-            Thing player = 2;
+            repeated RoleTypeWithPlayer role_type_with_player = 1;
         }
     }
 
@@ -299,7 +302,7 @@ message Attribute {
         }
         // @Iterable
         message Res {
-            Thing thing = 1;
+            repeated Thing thing = 1;
         }
     }
 
@@ -462,7 +465,7 @@ message Type {
         message Req {}
         // @Iterable
         message Res {
-            Type type = 1;
+            repeated Type type = 1;
         }
     }
 
@@ -470,7 +473,7 @@ message Type {
         message Req {}
         // @Iterable
         message Res {
-            Type type = 1;
+            repeated Type type = 1;
         }
     }
 }
@@ -490,7 +493,7 @@ message RoleType {
         message Req {}
         // @Iterable
         message Res {
-            Type relationType = 1;
+            repeated Type relationType = 1;
         }
     }
 
@@ -498,7 +501,7 @@ message RoleType {
         message Req {}
         // @Iterable
         message Res {
-            Type thingType = 1;
+            repeated Type thingType = 1;
         }
     }
 }
@@ -534,7 +537,7 @@ message ThingType {
         }
         // @Iterable
         message Res {
-            Type attribute_type = 1;
+            repeated Type attribute_type = 1;
         }
     }
 
@@ -542,7 +545,7 @@ message ThingType {
         message Req {}
         // @Iterable
         message Res {
-            Type role = 1;
+            repeated Type role = 1;
         }
     }
 
@@ -609,7 +612,7 @@ message RelationType {
         message Req {}
         // @Iterable
         message Res {
-            Type role = 1;
+            repeated Type role = 1;
         }
     }
 
@@ -681,7 +684,7 @@ message AttributeType {
         }
         // @Iterable
         message Res {
-            Type owner = 1;
+            repeated Type owner = 1;
         }
     }
 
@@ -707,7 +710,7 @@ message AttributeType {
         }
         // @Iterable
         message Res {
-            Type type = 1;
+            repeated Type type = 1;
         }
     }
 
@@ -719,7 +722,7 @@ message AttributeType {
         }
         // @Iterable
         message Res {
-            Thing thing = 1;
+            repeated Thing thing = 1;
         }
     }
 }

--- a/protobuf/query.proto
+++ b/protobuf/query.proto
@@ -57,7 +57,7 @@ message Graql {
         }
         // @Iterable
         message Res {
-            ConceptMap answer = 1;
+            repeated ConceptMap answer = 1;
         }
     }
 
@@ -67,7 +67,7 @@ message Graql {
         }
         // @Iterable
         message Res {
-            ConceptMap answer = 1;
+            repeated ConceptMap answer = 1;
         }
     }
 

--- a/protobuf/query.proto
+++ b/protobuf/query.proto
@@ -55,7 +55,6 @@ message Graql {
         message Req {
             string query = 1;
         }
-        // @Iterable
         message Res {
             repeated ConceptMap answer = 1;
         }
@@ -65,7 +64,6 @@ message Graql {
         message Req {
             string query = 1;
         }
-        // @Iterable
         message Res {
             repeated ConceptMap answer = 1;
         }


### PR DESCRIPTION
## What is the goal of this PR?

We have observed performance hit caused by sending large amount of grpc calls, to overcome the issue, we allow multiple answers to be batched within one grpc message and we batch them in one grpc call. This way we reduce the number calls we need to make to grpc.

## What are the changes implemented in this PR?

- Make the messages that server may stream back multiple answers into `repeated` field.

