### PR TITLE
Add session pulse and configurable timeouts

### DIFF
--- a/protobuf/grakn.proto
+++ b/protobuf/grakn.proto
@@ -35,7 +35,9 @@ service Grakn {
 
     rpc session_open (Session.Open.Req) returns (Session.Open.Res);
     rpc session_close (Session.Close.Req) returns (Session.Close.Res);
-    rpc session_keep_alive (Session.KeepAlive.Req) returns (Session.KeepAlive.Res);
+
+    // Checks with the server that the session is still alive, and informs it that it should be kept alive.
+    rpc session_pulse (Session.Pulse.Req) returns (Session.Pulse.Res);
 
     // Opens a bi-directional stream representing a stateful transaction, streaming
     // requests and responses back-and-forth. The first request message must

--- a/protobuf/grakn.proto
+++ b/protobuf/grakn.proto
@@ -35,6 +35,7 @@ service Grakn {
 
     rpc session_open (Session.Open.Req) returns (Session.Open.Res);
     rpc session_close (Session.Close.Req) returns (Session.Close.Res);
+    rpc session_keep_alive (Session.KeepAlive.Req) returns (Session.KeepAlive.Res);
 
     // Opens a bi-directional stream representing a stateful transaction, streaming
     // requests and responses back-and-forth. The first request message must

--- a/protobuf/options.proto
+++ b/protobuf/options.proto
@@ -35,4 +35,10 @@ message Options {
     oneof batch_size_opt {
         int32 batch_size = 3;
     }
+    oneof idle_timeout_opt {
+        int32 idle_timeout_millis = 4;
+    }
+    oneof acquire_lock_timeout_opt {
+        int32 acquire_lock_timeout_millis = 5;
+    }
 }

--- a/protobuf/options.proto
+++ b/protobuf/options.proto
@@ -38,7 +38,7 @@ message Options {
     oneof idle_timeout_opt {
         int32 idle_timeout_millis = 4;
     }
-    oneof acquire_lock_timeout_opt {
-        int32 acquire_lock_timeout_millis = 5;
+    oneof acquire_schema_lock_timeout_opt {
+        int32 acquire_schema_lock_timeout_millis = 5;
     }
 }

--- a/protobuf/options.proto
+++ b/protobuf/options.proto
@@ -35,10 +35,10 @@ message Options {
     oneof batch_size_opt {
         int32 batch_size = 3;
     }
-    oneof idle_timeout_opt {
-        int32 idle_timeout_millis = 4;
+    oneof session_idle_timeout_opt {
+        int32 session_idle_timeout_millis = 4;
     }
-    oneof acquire_schema_lock_timeout_opt {
-        int32 acquire_schema_lock_timeout_millis = 5;
+    oneof schema_lock_acquire_timeout_opt {
+        int32 schema_lock_acquire_timeout_millis = 5;
     }
 }

--- a/protobuf/session.proto
+++ b/protobuf/session.proto
@@ -53,6 +53,8 @@ message Session {
         message Req {
             bytes session_id = 1;
         }
-        message Res {}
+        message Res {
+            bool alive = 1;
+        }
     }
 }

--- a/protobuf/session.proto
+++ b/protobuf/session.proto
@@ -48,4 +48,11 @@ message Session {
         }
         message Res {}
     }
+
+    message KeepAlive {
+        message Req {
+            bytes session_id = 1;
+        }
+        message Res {}
+    }
 }

--- a/protobuf/session.proto
+++ b/protobuf/session.proto
@@ -49,7 +49,7 @@ message Session {
         message Res {}
     }
 
-    message KeepAlive {
+    message Pulse {
         message Req {
             bytes session_id = 1;
         }


### PR DESCRIPTION
## What is the goal of this PR?

1) To ensure Grakn remains usable after a client holding a schema session terminates abruptly: see https://github.com/graknlabs/client-java/issues/193 
2) To improve the UX of waiting for a lock to open a session or transaction: see https://github.com/graknlabs/client-java/issues/194 .

## What are the changes implemented in this PR?

- Add Session.Pulse
- Add new options: IdleTimeoutMillis and AcquireSchemaLockTimeoutMillis
