### PR TITLE
Fix build job

### DIFF
--- a/protobuf/BUILD
+++ b/protobuf/BUILD
@@ -96,6 +96,7 @@ filegroup(
         "query.proto",
         "session.proto",
         "transaction.proto",
+        "logic.proto",
     ]
 )
 


### PR DESCRIPTION
## What is the goal of this PR?

Currently, `build` is broken and fails with the following error:
```
Error: Command failed: /home/grabl/protocol/node_modules/grpc-tools/bin/protoc --plugin=protoc-gen-grpc=/home/grabl/protocol/node_modules/grpc-tools/bin/grpc_node_plugin --plugin=protoc-gen-ts=external/npm/node_modules/grpc_tools_node_protoc_ts/bin/protoc-gen-ts --js_out=import_style=commonjs,binary:./bazel-out/k8-fastbuild/bin/grpc/nodejs/ --grpc_out=grpc_js:./bazel-out/k8-fastbuild/bin/grpc/nodejs/ --ts_out=grpc_js:./bazel-out/k8-fastbuild/bin/grpc/nodejs/ --proto_path=. protobuf/answer.proto protobuf/concept.proto protobuf/database.proto protobuf/grakn.proto protobuf/options.proto protobuf/query.proto protobuf/session.proto protobuf/transaction.proto
protobuf/logic.proto: File not found.
protobuf/transaction.proto:24:1: Import "protobuf/logic.proto" was not found or had errors.
protobuf/transaction.proto:45:13: "LogicManager.Req" is not defined.
protobuf/transaction.proto:46:13: "Rule.Req" is not defined.
protobuf/transaction.proto:62:13: "LogicManager.Res" is not defined.
protobuf/transaction.proto:63:13: "Rule.Res" is not defined.
protobuf/grakn.proto:25:1: Import "protobuf/transaction.proto" was not found or had errors.
protobuf/grakn.proto:45:29: "Transaction.Req" is not defined.
protobuf/grakn.proto:45:62: "Transaction.Res" is not defined.
```

This happens due to not including `logic.proto` as source when building NodeJS package.

## What are the changes implemented in this PR?

Include `logic.proto` into `//protocol:proto-raw-buffers`