### PR TITLE
Make grpc/python package correctly importable with pip

### DIFF
--- a/grpc/python/BUILD
+++ b/grpc/python/BUILD
@@ -46,7 +46,7 @@ python_repackage(
 py_library(
     name = "protocol",
     srcs = ["protocol_pkg"],
-    imports = ["../../grpc/python"]
+    imports = ["../../../grpc/python"]
 )
 
 checkstyle_test(


### PR DESCRIPTION
## What is the goal of this PR?

Make grpc/python package correctly importable with pip.

## What are the changes implemented in this PR?

- Do some magic that makes the `py_library` compatible with pip