### PR TITLE
Simplify NodeJS proto compilation

### DIFF
--- a/grpc/nodejs/BUILD
+++ b/grpc/nodejs/BUILD
@@ -71,24 +71,22 @@ genrule(
     #    Output typescript to (you guessed it) the genrule output directory
     #    Set the .proto file relative path to the WORKSPACE this command is being run from
     #    Use the .proto files found in the :proto-raw-buffers filegroup as inputs.
-    cmd = "ln -s $(execpath //grpc/nodejs:protoc-gen-ts).runfiles/npm/node_modules ./node_modules ;\
-        $(execpath //grpc/nodejs:grpc_tools_node_protoc) \
+    cmd = "$(execpath //grpc/nodejs:grpc_tools_node_protoc) \
             --plugin='protoc-gen-ts=$(rootpath @npm//:node_modules/grpc_tools_node_protoc_ts/bin/protoc-gen-ts)' \
             --js_out='import_style=commonjs,binary:./$(@D)/' \
             --grpc_out='grpc_js:./$(@D)/' \
             --ts_out='grpc_js:./$(@D)/' \
-            --proto_path=`dirname $(execpath //:WORKSPACE)` \
-            $(execpaths //protobuf:proto-raw-buffers);",
-    # Dependencies for the above command. the //:WORKSPACE label is required to locate the relative path for the .proto files so they can import each other.
+            --proto_path=. \
+            $(locations //protobuf:proto-raw-buffers);",
     tools = [
         "//grpc/nodejs:grpc_tools_node_protoc",
-        "//grpc/nodejs:protoc-gen-ts",
         "@npm//:node_modules/grpc_tools_node_protoc_ts/bin/protoc-gen-ts",
         "@npm//grpc_tools_node_protoc_ts",
         "@npm//google-protobuf",
-        "//protobuf:proto-raw-buffers",
-        "//:WORKSPACE"
     ],
+    srcs = [
+        "//protobuf:proto-raw-buffers",
+    ]
 )
 
 pkg_npm(

--- a/grpc/nodejs/BUILD
+++ b/grpc/nodejs/BUILD
@@ -63,13 +63,12 @@ genrule(
         "protobuf/transaction_pb.js",
     ],
     # The below command performs a protoc compilation of our proto files into typescript and javascript. Line by line:
-    # Symlink the node modules required by the typescript plugin into the directory the command will be run from
     # Run the node.js protoc (protocol compiler) with the following flags:
     #    Use the gen-ts plugin to generate typescript declaration files in addition to javascript
     #    Output javascript with commonjs style exports, to the genrule output directory.
     #    Output services to the genrule output directory (without this line, grakn_grpc_pb is omitted)
     #    Output typescript to (you guessed it) the genrule output directory
-    #    Set the .proto file relative path to the WORKSPACE this command is being run from
+    #    Set the .proto file relative path to root folder (same as where WORKSPACE resides)
     #    Use the .proto files found in the :proto-raw-buffers filegroup as inputs.
     cmd = "$(execpath //grpc/nodejs:grpc_tools_node_protoc) \
             --plugin='protoc-gen-ts=$(rootpath @npm//:node_modules/grpc_tools_node_protoc_ts/bin/protoc-gen-ts)' \
@@ -77,7 +76,7 @@ genrule(
             --grpc_out='grpc_js:./$(@D)/' \
             --ts_out='grpc_js:./$(@D)/' \
             --proto_path=. \
-            $(locations //protobuf:proto-raw-buffers);",
+            $(execpaths //protobuf:proto-raw-buffers);",
     tools = [
         "//grpc/nodejs:grpc_tools_node_protoc",
         "@npm//:node_modules/grpc_tools_node_protoc_ts/bin/protoc-gen-ts",


### PR DESCRIPTION
## What is the goal of this PR?

Simplify the `genrule` that builds our protocol for Typescript

## What are the changes implemented in this PR?

* Move `//protobuf:proto-raw-buffers` into `srcs` since this is what they are
* Remove symlinking `node_modules` - not needed
* `dirname $(execpath //:WORKSPACE)` always evaluates to `.` (since `WORKSPACE` is a top-level file)
