### PR TITLE
Build Java code to be compatible with older Java

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-build --incompatible_strict_action_env
+build --incompatible_strict_action_env --javacopt='--release 8'
 run --incompatible_strict_action_env
 test --incompatible_strict_action_env
 


### PR DESCRIPTION
## What is the goal of this PR?

Currently, we compile Protocol on CI with Java 11. This could result in unexpected runtime issues when running on older Java, such as `java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer;` that we experienced.

## What are the changes implemented in this PR?

Pass Java compiler option to produce bytecode compatible with Java 8