### PR TITLE
Update how we pass requirements to assemble_pip

### DIFF
--- a/grpc/python/BUILD
+++ b/grpc/python/BUILD
@@ -21,6 +21,8 @@ load("@graknlabs_bazel_distribution//pip:rules.bzl", "assemble_pip", "deploy_pip
 load("@graknlabs_dependencies//distribution:deployment.bzl", "deployment")
 load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 
+exports_files(["requirements.txt"])
+
 python_grpc_compile(
     name = "protocol_src",
     deps = [


### PR DESCRIPTION
## What is the goal of this PR?

Recently, we've upgraded how Python package dependencies are passed to `assemble_pip` rule. Therefore, all usages of `assemble_pip` need to be updated.

## What are the changes implemented in this PR?

Pass `requirements.txt` to `assemble_pip`