### PR TITLE
Switch image back to default Ubuntu 20.04

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -26,7 +26,7 @@ build:
       owner: graknlabs
       branch: master
     dependency-analysis:
-      image: graknlabs-ubuntu-20.04-java11
+      image: graknlabs-ubuntu-20.04
       script: |
         bazel run @graknlabs_dependencies//grabl/analysis:dependency-analysis
   correctness:


### PR DESCRIPTION
## What is the goal of this PR?

Recent version of default GraknLabs Ubuntu image already has Java 11 as default, so specialized version (`-java11`) should no longer be used.

## What are the changes implemented in this PR?

Use `graknlabs-ubuntu-20.04` as image for all jobs