### PR TITLE
Rename Python protocol package to grakn-protocol

### DIFF
--- a/grpc/python/BUILD
+++ b/grpc/python/BUILD
@@ -59,7 +59,7 @@ checkstyle_test(
 assemble_pip(
     name = "assemble-pip",
     target = ":protocol",
-    package_name = "graknprotocol",
+    package_name = "grakn-protocol",
     classifiers = [
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
## What is the goal of this PR?

Make package naming consistent across multiple language repositories

## What are the changes implemented in this PR?

Rename Python Grakn Protocol package to `grakn-protocol` in order to be consistent with Client NodeJs and Client Java package naming.