### PR TITLE
Fix console warnings caused by out of date dependency

### DIFF
--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -21,5 +21,5 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "b602038674e26cbdc9c0959e5e4de8938867e9b9", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "fcc3a69b8f0cdd2d56c8faccbedea5f39d2a345c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -17,7 +17,7 @@
 @maven//:com_google_j2objc_j2objc_annotations
 @maven//:com_google_j2objc_j2objc_annotations_1_3
 @maven//:com_google_protobuf_protobuf_java
-@maven//:com_google_protobuf_protobuf_java_3_5_1
+@maven//:com_google_protobuf_protobuf_java_3_14_0
 @maven//:commons_codec_commons_codec
 @maven//:commons_codec_commons_codec_1_11
 @maven//:commons_io_commons_io


### PR DESCRIPTION
## What is the goal of this PR?

Fix `WARNING: An illegal reflective access operation has occurred` warning caused by an out of date version of protobuf.

## What are the changes implemented in this PR?

- Update protobuf to latest.