### PR TITLE
Introduce a new transaction type for reading from secondary replicas

### DIFF
--- a/protobuf/cluster/database.proto
+++ b/protobuf/cluster/database.proto
@@ -34,7 +34,7 @@ message Database {
             message Replica {
                 string address = 1;
                 string database = 2;
-                bool is_leader = 3;
+                bool is_primary = 3;
                 int64 term = 4;
             }
         }

--- a/protobuf/options.proto
+++ b/protobuf/options.proto
@@ -44,7 +44,7 @@ message Options {
     oneof schema_lock_acquire_timeout_opt {
         int32 schema_lock_acquire_timeout_millis = 6;
     }
-    oneof primary_replica_opt {
-        bool primary_replica = 7;
+    oneof allow_secondary_replica_opt {
+        bool allow_secondary_replica = 7;
     }
 }

--- a/protobuf/options.proto
+++ b/protobuf/options.proto
@@ -44,4 +44,7 @@ message Options {
     oneof schema_lock_acquire_timeout_opt {
         int32 schema_lock_acquire_timeout_millis = 6;
     }
+    oneof primary_replica_opt {
+        bool primary_replica = 6;
+    }
 }

--- a/protobuf/options.proto
+++ b/protobuf/options.proto
@@ -45,6 +45,6 @@ message Options {
         int32 schema_lock_acquire_timeout_millis = 6;
     }
     oneof primary_replica_opt {
-        bool primary_replica = 6;
+        bool primary_replica = 7;
     }
 }

--- a/protobuf/transaction.proto
+++ b/protobuf/transaction.proto
@@ -67,6 +67,7 @@ message Transaction {
     enum Type {
         READ = 0;
         WRITE = 1;
+        READ_SECONDARY = 2;
     }
 
     message Open {

--- a/protobuf/transaction.proto
+++ b/protobuf/transaction.proto
@@ -67,7 +67,6 @@ message Transaction {
     enum Type {
         READ = 0;
         WRITE = 1;
-        READ_SECONDARY = 2;
     }
 
     message Open {


### PR DESCRIPTION
## What is the goal of this PR?

We've introduced a new Grakn-Cluster-specific transaction type, "read secondary". It is a read-only transaction that may read not only from primary but also from secondary replicas.

## What are the changes implemented in this PR?

- Adds a new option `allow_secondary_replica`