### PR TITLE
Add prefetch option

### DIFF
--- a/protobuf/options.proto
+++ b/protobuf/options.proto
@@ -35,10 +35,13 @@ message Options {
     oneof batch_size_opt {
         int32 batch_size = 3;
     }
+    oneof prefetch_opt {
+        bool prefetch = 4;
+    }
     oneof session_idle_timeout_opt {
-        int32 session_idle_timeout_millis = 4;
+        int32 session_idle_timeout_millis = 5;
     }
     oneof schema_lock_acquire_timeout_opt {
-        int32 schema_lock_acquire_timeout_millis = 5;
+        int32 schema_lock_acquire_timeout_millis = 6;
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

On executing a Graql query, Grakn automatically streams the first batch of responses back to the client. But, for an `insert` query, they usually don't need those answers. To remedy this, we made `prefetch` a configurable per-query option.

## What are the changes implemented in this PR?

Add prefetch option