### PR TITLE
Reenable remote build caching

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,11 +22,8 @@ test --incompatible_strict_action_env
 # what is defined in this section will be applied when bazel is invoked like this: bazel ... --config=rbe ...
 build:rbe --project_id=grakn-dev
 build:rbe --remote_cache=cloud.buildbuddy.io
-build:rbe --remote_executor=cloud.buildbuddy.io
 build:rbe --bes_backend=cloud.buildbuddy.io
 build:rbe --bes_results_url=https://app.buildbuddy.io/invocation/
 build:rbe --tls_client_certificate=/opt/credentials/buildbuddy-cert.pem
 build:rbe --tls_client_key=/opt/credentials/buildbuddy-key.pem
-build:rbe --host_platform=@graknlabs_dependencies//image/buildbuddy:ubuntu-2004
-build:rbe --jobs=50
 build:rbe --remote_timeout=3600

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -34,15 +34,15 @@ build:
       image: graknlabs-ubuntu-20.04
       #NPM packages can't be built under RBE
       command: |
-        bazel build //...
-        bazel run @graknlabs_dependencies//tool/checkstyle:test-coverage
-        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
+        bazel build --config=rbe //...
+        bazel run --config=rbe @graknlabs_dependencies//tool/checkstyle:test-coverage
+        bazel test --config=rbe $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
     build-dependency:
       image: graknlabs-ubuntu-20.04
       command: |
         dependencies/maven/update.sh
         git diff --exit-code dependencies/maven/artifacts.snapshot
-        bazel run @graknlabs_dependencies//tool/unuseddeps:unused-deps -- list
+        bazel run --config=rbe @graknlabs_dependencies//tool/unuseddeps:unused-deps -- list
     deploy-maven-snapshot:
       filter:
         owner: graknlabs
@@ -52,7 +52,7 @@ build:
       command: |
         export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
         export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
-        bazel run --define version=$(git rev-parse HEAD) //grpc/java:deploy-maven -- snapshot
+        bazel run --config=rbe --define version=$(git rev-parse HEAD) //grpc/java:deploy-maven -- snapshot
     deploy-npm-snapshot:
       filter:
         owner: graknlabs
@@ -66,7 +66,7 @@ build:
         export DEPLOY_NPM_USERNAME=$REPO_GRAKN_USERNAME
         export DEPLOY_NPM_PASSWORD=$REPO_GRAKN_PASSWORD
         export DEPLOY_NPM_EMAIL=$REPO_GRAKN_EMAIL
-        bazel run --define version=$(git rev-parse HEAD) //grpc/nodejs:deploy-npm -- snapshot
+        bazel run --config=rbe --define version=$(git rev-parse HEAD) //grpc/nodejs:deploy-npm -- snapshot
       dependencies: [build, build-dependency]
     deploy-pip-snapshot:
       filter:
@@ -95,13 +95,13 @@ release:
         export RELEASE_NOTES_TOKEN=$REPO_GITHUB_TOKEN
         bazel run @graknlabs_dependencies//tool/release:create-notes -- protocol $(cat VERSION) ./RELEASE_TEMPLATE.md
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
-        bazel run --define version=$(cat VERSION) //:deploy-github -- $GRABL_COMMIT
+        bazel run --config=rbe --define version=$(cat VERSION) //:deploy-github -- $GRABL_COMMIT
     deploy-maven-release:
       image: graknlabs-ubuntu-20.04
       command: |
         export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
         export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
-        bazel run --define version=$(cat VERSION) //grpc/java:deploy-maven -- release
+        bazel run --config=rbe --define version=$(cat VERSION) //grpc/java:deploy-maven -- release
       dependencies: [deploy-github]
     deploy-npm-release:
       image: graknlabs-ubuntu-20.04
@@ -113,7 +113,7 @@ release:
         export DEPLOY_NPM_USERNAME=$REPO_NPM_USERNAME
         export DEPLOY_NPM_PASSWORD=$REPO_NPM_PASSWORD
         export DEPLOY_NPM_EMAIL=$REPO_GRAKN_EMAIL
-        bazel run --define version=$(cat VERSION) //grpc/nodejs:deploy-npm -- release
+        bazel run --config=rbe --define version=$(cat VERSION) //grpc/nodejs:deploy-npm -- release
       dependencies: [deploy-github]
     deploy-pip-release:
       image: graknlabs-ubuntu-20.04
@@ -124,5 +124,5 @@ release:
         sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.6.10/lib/python3.6/site-packages/lsb_release.py
         export DEPLOY_PIP_USERNAME=$REPO_PYPI_USERNAME
         export DEPLOY_PIP_PASSWORD=$REPO_PYPI_PASSWORD
-        bazel run --define version=$(cat VERSION) //grpc/python:deploy-pip -- release
+        bazel run --config=rbe --define version=$(cat VERSION) //grpc/python:deploy-pip -- release
       dependencies: [deploy-github]


### PR DESCRIPTION
## What is the goal of this PR?

Speed up builds by utilizing remote caching provided by BuildBuddy.

## What are the changes implemented in this PR?

Reenable build caching (without remote execution) on all CI jobs