### PR TITLE
Rename Python package in pip artifact to grakn_protocol

### DIFF
--- a/grpc/python/BUILD
+++ b/grpc/python/BUILD
@@ -40,7 +40,7 @@ python_grpc_compile(
 python_repackage(
     name = "protocol_pkg",
     src = ":protocol_src",
-    package = "graknprotocol"
+    package = "grakn_protocol"
 )
 
 py_library(


### PR DESCRIPTION
## What is the goal of this PR?

Our pip artifact is named `grakn-protocol` but the Python package used to import Python objects from it was inconsistently named `graknprotocol`. So we've renamed it to `grakn_protocol`.

## What are the changes implemented in this PR?

In pip artifact, rename Python package used in imports to grakn_protocol
