### PR TITLE
Fix pip package using wrong Python package names

### DIFF
--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -21,5 +21,5 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "fcc3a69b8f0cdd2d56c8faccbedea5f39d2a345c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "d8cce4fbec3c059232b9101a0c75422cd2e0ea7a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )

--- a/grpc/python/BUILD
+++ b/grpc/python/BUILD
@@ -50,13 +50,15 @@ python_grpc_compile(
 python_repackage(
     name = "protocol-pkg",
     src = ":protocol-src",
-    package = "grakn_protocol"
+    src_package = "protobuf",
+    py_package_add_prefix = "grakn_protocol",
 )
 
 python_repackage(
     name = "protocol-cluster-pkg",
     src = ":protocol-cluster-src",
-    package = "grakn_protocol"
+    src_package = "protobuf.cluster",
+    py_package_add_prefix = "grakn_protocol",
 )
 
 py_library(


### PR DESCRIPTION
## What is the goal of this PR?

The Python package names generated for our Cluster proto files were incorrect. We updated our `python_repackage` rules to fix it.

## What are the changes implemented in this PR?

Update our `python_repackage` rules that run against Python package targets so that the Cluster proto files use the correct import paths