### PR TITLE
Clarify Cluster service methods and introduce "preferred secondary" replica

### DIFF
--- a/protobuf/cluster/cluster.proto
+++ b/protobuf/cluster/cluster.proto
@@ -23,7 +23,7 @@ option java_outer_classname = "ClusterProto";
 package grakn.protocol.cluster;
 
 message Cluster {
-    message Discover {
+    message Servers {
         message Req {}
         message Res {
             repeated string servers = 1;

--- a/protobuf/cluster/database.proto
+++ b/protobuf/cluster/database.proto
@@ -23,20 +23,27 @@ option java_outer_classname = "DatabaseProto";
 package grakn.protocol.cluster;
 
 message Database {
-    message Discover {
+
+    message Replica {
+        string address = 1;
+        string database = 2;
+        Rank rank = 3;
+        int64 term = 4;
+
+        enum Rank {
+            PRIMARY = 0;
+            SECONDARY = 1;
+            BACKUP = 2;
+        }
+    }
+
+    message Replicas {
         message Req {
             string database = 1;
         }
 
         message Res {
             repeated Replica replicas = 1;
-
-            message Replica {
-                string address = 1;
-                string database = 2;
-                bool is_primary = 3;
-                int64 term = 4;
-            }
         }
     }
 }

--- a/protobuf/cluster/database.proto
+++ b/protobuf/cluster/database.proto
@@ -27,14 +27,9 @@ message Database {
     message Replica {
         string address = 1;
         string database = 2;
-        Rank rank = 3;
-        int64 term = 4;
-
-        enum Rank {
-            PRIMARY = 0;
-            SECONDARY = 1;
-            BACKUP = 2;
-        }
+        bool primary = 3;
+        bool preferred_secondary = 4;
+        int64 term = 5;
     }
 
     message Replicas {

--- a/protobuf/cluster/grakn_cluster.proto
+++ b/protobuf/cluster/grakn_cluster.proto
@@ -26,6 +26,6 @@ import "protobuf/cluster/database.proto";
 package grakn.protocol.cluster;
 
 service GraknCluster {
-    rpc cluster_discover (Cluster.Discover.Req) returns (Cluster.Discover.Res);
-    rpc database_discover (Database.Discover.Req) returns (Database.Discover.Res);
+    rpc cluster_servers (Cluster.Servers.Req) returns (Cluster.Servers.Res);
+    rpc database_replicas (Database.Replicas.Req) returns (Database.Replicas.Res);
 }


### PR DESCRIPTION
## What is the goal of this PR?

Cluster database replicas can now be _preferred secondary replicas_. To encapsulate this we added the flag `preferred_secondary` to `cluster.Database.Replica`.

Additionally, we made the Cluster service methods more transparent by naming them `Cluster.Servers` and `Database.Replicas` (previously `Cluster.Discover` and `Database.Discover`)

## What are the changes implemented in this PR?

- Rename `Cluster.Discover` to `Cluster.Servers`
- Rename `Database.Discover` to `Database.Replicas`
- Add `preferred_secondary` to `cluster.Database.Replica`
