### PR TITLE
Add inference logging option

### DIFF
--- a/protobuf/options.proto
+++ b/protobuf/options.proto
@@ -29,8 +29,8 @@ message Options {
     oneof infer_opt {
         bool infer = 1;
     }
-    oneof infer_log_opt {
-        bool infer_log = 2;
+    oneof trace_inference_opt {
+        bool trace_inference = 2;
     }
     oneof explain_opt {
         bool explain = 3;

--- a/protobuf/options.proto
+++ b/protobuf/options.proto
@@ -26,11 +26,11 @@ package grakn.protocol;
 // https://github.com/protocolbuffers/protobuf/issues/1606#issuecomment-618687169
 
 message Options {
-    oneof inference_opt {
-        bool inference = 1;
+    oneof infer_opt {
+        bool infer = 1;
     }
-    oneof inference_logging_opt {
-        bool inference_logging = 2;
+    oneof infer_log_opt {
+        bool infer_log = 2;
     }
     oneof explain_opt {
         bool explain = 3;

--- a/protobuf/options.proto
+++ b/protobuf/options.proto
@@ -26,25 +26,28 @@ package grakn.protocol;
 // https://github.com/protocolbuffers/protobuf/issues/1606#issuecomment-618687169
 
 message Options {
-    oneof infer_opt {
-        bool infer = 1;
+    oneof inference_opt {
+        bool inference = 1;
+    }
+    oneof inference_logging_opt {
+        bool inference_logging = 2;
     }
     oneof explain_opt {
-        bool explain = 2;
+        bool explain = 3;
     }
     oneof batch_size_opt {
-        int32 batch_size = 3;
+        int32 batch_size = 4;
     }
     oneof prefetch_opt {
-        bool prefetch = 4;
+        bool prefetch = 5;
     }
     oneof session_idle_timeout_opt {
-        int32 session_idle_timeout_millis = 5;
+        int32 session_idle_timeout_millis = 6;
     }
     oneof schema_lock_acquire_timeout_opt {
-        int32 schema_lock_acquire_timeout_millis = 6;
+        int32 schema_lock_acquire_timeout_millis = 7;
     }
     oneof read_any_replica_opt {
-        bool read_any_replica = 7;
+        bool read_any_replica = 8;
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

Add an option that allows users to turn on or off resolution tracing for reasoner. 

## What are the changes implemented in this PR?

- Inference tracing is intended to be set to true only when parallel is set to false.