### PR TITLE
Add parallel option to Options

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -54,9 +54,9 @@ build:
         export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //grpc/java:deploy-maven -- snapshot
     deploy-npm-snapshot:
-      filter:
-        owner: graknlabs
-        branch: master
+#      filter:
+#        owner: graknlabs
+#        branch: master
       image: graknlabs-ubuntu-20.04
       command: |
         curl https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
@@ -69,9 +69,9 @@ build:
         bazel run --define version=$(git rev-parse HEAD) //grpc/nodejs:deploy-npm -- snapshot
       dependencies: [build, build-dependency]
     deploy-pip-snapshot:
-      filter:
-        owner: graknlabs
-        branch: master
+#      filter:
+#        owner: graknlabs
+#        branch: master
       image: graknlabs-ubuntu-20.04
       type: foreground
       command: |

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -54,9 +54,9 @@ build:
         export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //grpc/java:deploy-maven -- snapshot
     deploy-npm-snapshot:
-#      filter:
-#        owner: graknlabs
-#        branch: master
+      filter:
+        owner: graknlabs
+        branch: master
       image: graknlabs-ubuntu-20.04
       command: |
         curl https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
@@ -69,9 +69,9 @@ build:
         bazel run --define version=$(git rev-parse HEAD) //grpc/nodejs:deploy-npm -- snapshot
       dependencies: [build, build-dependency]
     deploy-pip-snapshot:
-#      filter:
-#        owner: graknlabs
-#        branch: master
+      filter:
+        owner: graknlabs
+        branch: master
       image: graknlabs-ubuntu-20.04
       type: foreground
       command: |

--- a/protobuf/options.proto
+++ b/protobuf/options.proto
@@ -41,13 +41,16 @@ message Options {
     oneof prefetch_opt {
         bool prefetch = 5;
     }
+    oneof parallel_opt {
+      bool parallel = 6;
+    }
     oneof session_idle_timeout_opt {
-        int32 session_idle_timeout_millis = 6;
+        int32 session_idle_timeout_millis = 7;
     }
     oneof schema_lock_acquire_timeout_opt {
-        int32 schema_lock_acquire_timeout_millis = 7;
+        int32 schema_lock_acquire_timeout_millis = 8;
     }
     oneof read_any_replica_opt {
-        bool read_any_replica = 8;
+        bool read_any_replica = 9;
     }
 }

--- a/protobuf/options.proto
+++ b/protobuf/options.proto
@@ -35,14 +35,14 @@ message Options {
     oneof explain_opt {
         bool explain = 3;
     }
+    oneof parallel_opt {
+      bool parallel = 4;
+    }
     oneof batch_size_opt {
-        int32 batch_size = 4;
+        int32 batch_size = 5;
     }
     oneof prefetch_opt {
-        bool prefetch = 5;
-    }
-    oneof parallel_opt {
-      bool parallel = 6;
+        bool prefetch = 6;
     }
     oneof session_idle_timeout_opt {
         int32 session_idle_timeout_millis = 7;


### PR DESCRIPTION
## What is the goal of this PR?
To allow clients to disable parallel execution, we add the `parallel_opt` to `Options.

## What are the changes implemented in this PR?
* add `parallel_opt` to `Options.
