### PR TITLE
Add 'type' field to Thing

### DIFF
--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -105,9 +105,8 @@ message Concept {
 message Thing {
 
     bytes iid = 1;
-    Encoding encoding = 2;
-    AttributeType.ValueType value_type = 3;
-    Attribute.Value value = 4;
+    Type type = 2;
+    Attribute.Value value = 3;
 
     message Req {
         bytes iid = 1;

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -155,12 +155,6 @@ message Thing {
         }
     }
 
-    enum Encoding {
-        ENTITY = 0;
-        RELATION = 1;
-        ATTRIBUTE = 2;
-    }
-
     message Delete {
         message Req {}
         message Res {}


### PR DESCRIPTION
## What is the goal of this PR?

The `Thing` message now contains a new field, `type`, which holds the concept type. As a result of this change, `value_type` is now redundant (equivalent to `type.value_type`) and `encoding` can be inferred from `type.encoding`, so both fields have been deleted.

## What are the changes implemented in this PR?

Add 'type' field to Thing message; delete `value_type` and `encoding`
