### PR TITLE
Introduced transaction request batching

### DIFF
--- a/protobuf/grakn.proto
+++ b/protobuf/grakn.proto
@@ -40,8 +40,8 @@ service Grakn {
     rpc session_pulse (Session.Pulse.Req) returns (Session.Pulse.Res);
 
     // Opens a bi-directional stream representing a stateful transaction, streaming
-    // requests and responses back-and-forth. The first request message must
+    // requests and responses back-and-forth. The first transaction request must
     // be {Transaction.Open.Req}. Closing the stream closes the transaction.
-    rpc transaction (stream Transaction.Req) returns (stream Transaction.Res);
+    rpc transaction (stream Transaction.Reqs) returns (stream Transaction.Res);
 
 }

--- a/protobuf/session.proto
+++ b/protobuf/session.proto
@@ -39,6 +39,7 @@ message Session {
         }
         message Res {
             bytes session_id = 1;
+            int32 processing_time_millis = 2;
         }
     }
 

--- a/protobuf/transaction.proto
+++ b/protobuf/transaction.proto
@@ -29,38 +29,40 @@ package grakn.protocol;
 
 message Transaction {
 
+    message Reqs {
+        repeated Transaction.Req transaction_reqs = 1;
+    }
+
     message Req {
         string id = 1;
         map<string, string> metadata = 2;
-        int32 latency_millis = 3;
         oneof req {
-            bool continue = 4;
-            Open.Req open_req = 5;
-            Commit.Req commit_req = 6;
-            Rollback.Req rollback_req = 7;
-            Query.Req query_req = 8;
-            ConceptManager.Req concept_manager_req = 9;
-            Thing.Req thing_req = 10;
-            grakn.protocol.Type.Req type_req = 11;
-            LogicManager.Req logic_manager_req = 12;
-            Rule.Req rule_req = 13;
+            Open.Req open_req = 3;
+            Iterate.Req iterate_req = 4;
+            Commit.Req commit_req = 5;
+            Rollback.Req rollback_req = 6;
+            Query.Req query_req = 7;
+            ConceptManager.Req concept_manager_req = 8;
+            Thing.Req thing_req = 9;
+            grakn.protocol.Type.Req type_req = 10;
+            LogicManager.Req logic_manager_req = 11;
+            Rule.Req rule_req = 12;
         }
     }
 
     message Res {
         string id = 1;
         oneof res {
-            bool done = 2;
-            bool continue = 4;
-            Open.Res open_res = 5;
-            Commit.Res commit_res = 6;
-            Rollback.Res rollback_res = 7;
-            Query.Res query_res = 8;
-            ConceptManager.Res concept_manager_res = 9;
-            Thing.Res thing_res = 10;
-            grakn.protocol.Type.Res type_res = 11;
-            LogicManager.Res logic_manager_res = 12;
-            Rule.Res rule_res = 13;
+            Open.Res open_res = 2;
+            Iterate.Res iterate_res = 3;
+            Commit.Res commit_res = 4;
+            Rollback.Res rollback_res = 5;
+            Query.Res query_res = 6;
+            ConceptManager.Res concept_manager_res = 7;
+            Thing.Res thing_res = 8;
+            grakn.protocol.Type.Res type_res = 9;
+            LogicManager.Res logic_manager_res = 10;
+            Rule.Res rule_res = 11;
         }
     }
 
@@ -74,9 +76,15 @@ message Transaction {
             bytes session_id = 1;
             Type type = 2;
             Options options = 3;
+            int32 latency_millis = 4;
         }
+        message Res {}
+    }
+
+    message Iterate {
+        message Req {}
         message Res {
-            int32 processing_time_millis = 1;
+            bool has_next = 1;
         }
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

When sending large amounts of requests from the client to server, it is possible to reach GRPC's maximum throughput of messages per second, on large scale systems. For example, a client with 32 cores, can have 1000 concurrent transactions sending requests to the server. This will easily go beyond what GRPC can handle, and thus becomes the bottleneck in the system. That client will not be sending as many requests it wants per second, and the server may still be able to handle more requests to handle. We have now overcome this problem, by allowing the transaction stream (the predominant GRPC service) to _"batch"_ the transaction requests into one GRPC message to send to the server, within a given time window. In the client-side implementations, we have chosen the time window to be 1 millisecond - small enough to not cause any noticeable performance degradation on individual requests, but big enough to _"batch"_ all requests within that time window into one message and multiply the throughput. 

Additionally, we also refined the messages to control iterators - `continue` and `done` - to be replaced with `Transaction.Iterate.Req` and `Transaction.Iterate.Res`, and we moved `latency_millis` into `Transaction.Open.Req`.

## What are the changes implemented in this PR?

- Introduced `Transaction.Reqs` which contains a list of `Transaction.Req`
- Introduced `Transaction.Iterate.Req` and `Transaction.Iterate.Res` to replace `continue` and `done`
- Moved `latency_millis` into `Transaction.Open.Req`