### PR TITLE
Architecture Refactor

### DIFF
--- a/protobuf/cluster/cluster.proto
+++ b/protobuf/cluster/cluster.proto
@@ -26,7 +26,7 @@ message Cluster {
     message Servers {
         message Req {}
         message Res {
-            repeated string servers = 1;
+            repeated string addresses = 1;
         }
     }
 }

--- a/protobuf/cluster/database.proto
+++ b/protobuf/cluster/database.proto
@@ -23,13 +23,14 @@ option java_outer_classname = "DatabaseProto";
 package grakn.protocol.cluster;
 
 message Database {
+
     string name = 1;
     repeated Replica replicas = 2;
 
     message Replica {
         string address = 1;
         bool primary = 2;
-        bool preferred_secondary = 3;
+        bool preferred = 3;
         int64 term = 4;
     }
 
@@ -37,7 +38,6 @@ message Database {
         message Req {
             string name = 1;
         }
-
         message Res {
             Database database = 1;
         }
@@ -45,7 +45,6 @@ message Database {
 
     message All {
         message Req {}
-
         message Res {
             repeated Database databases = 1;
         }

--- a/protobuf/cluster/grakn_cluster.proto
+++ b/protobuf/cluster/grakn_cluster.proto
@@ -26,8 +26,9 @@ import "protobuf/cluster/database.proto";
 package grakn.protocol.cluster;
 
 service GraknCluster {
-    rpc cluster_servers (Cluster.Servers.Req) returns (Cluster.Servers.Res);
 
+    rpc cluster_servers (Cluster.Servers.Req) returns (Cluster.Servers.Res);
     rpc database_get (Database.Get.Req) returns (Database.Get.Res);
     rpc database_all (Database.All.Req) returns (Database.All.Res);
+
 }

--- a/protobuf/concept.proto
+++ b/protobuf/concept.proto
@@ -140,18 +140,26 @@ message Thing {
             Thing.IsInferred.Res thing_is_inferred_res = 102;
             Thing.SetHas.Res thing_set_has_res = 103;
             Thing.UnsetHas.Res thing_unset_has_res = 104;
-            Thing.GetHas.Res thing_get_has_res = 105;
-            Thing.GetRelations.Res thing_get_relations_res = 106;
-            Thing.GetPlays.Res thing_get_plays_res = 107;
 
             // Relation method responses
             Relation.AddPlayer.Res relation_add_player_res = 200;
             Relation.RemovePlayer.Res relation_remove_player_res = 201;
-            Relation.GetPlayers.Res relation_get_players_res = 202;
-            Relation.GetPlayersByRoleType.Res relation_get_players_by_role_type_res = 203;
+        }
+    }
+
+    message ResPart {
+        oneof res {
+            // Thing method responses
+            Thing.GetHas.ResPart thing_get_has_res_part = 100;
+            Thing.GetRelations.ResPart thing_get_relations_res_part = 101;
+            Thing.GetPlays.ResPart thing_get_plays_res_part = 102;
+
+            // Relation method responses
+            Relation.GetPlayers.ResPart relation_get_players_res_part = 200;
+            Relation.GetPlayersByRoleType.ResPart relation_get_players_by_role_type_res_part = 201;
 
             // Attribute method responses
-            Attribute.GetOwners.Res attribute_get_owners_res = 300;
+            Attribute.GetOwners.ResPart attribute_get_owners_res_part = 300;
         }
     }
 
@@ -194,14 +202,14 @@ message Thing {
             repeated Type attribute_types = 1;
             bool keys_only = 2;
         }
-        message Res {
+        message ResPart {
             repeated Thing attributes = 1;
         }
     }
 
     message GetPlays {
         message Req {}
-        message Res {
+        message ResPart {
             repeated Type role_types = 1;
         }
     }
@@ -210,7 +218,7 @@ message Thing {
         message Req {
             repeated Type role_types = 1;
         }
-        message Res {
+        message ResPart {
             repeated Thing relations = 1;
         }
     }
@@ -222,7 +230,7 @@ message Relation {
         message Req {
             repeated Type role_types = 1;
         }
-        message Res {
+        message ResPart {
             repeated Thing things = 1;
         }
     }
@@ -233,7 +241,7 @@ message Relation {
             Thing player = 2;
         }
         message Req {}
-        message Res {
+        message ResPart {
             repeated RoleTypeWithPlayer role_types_with_players = 1;
         }
     }
@@ -263,7 +271,7 @@ message Attribute {
                 Type thing_type = 1;
             }
         }
-        message Res {
+        message ResPart {
             repeated Thing things = 1;
         }
     }
@@ -342,13 +350,9 @@ message Type {
             Type.IsAbstract.Res type_is_abstract_res = 102;
             Type.GetSupertype.Res type_get_supertype_res = 103;
             Type.SetSupertype.Res type_set_supertype_res = 104;
-            Type.GetSupertypes.Res type_get_supertypes_res = 105;
-            Type.GetSubtypes.Res type_get_subtypes_res = 106;
 
             // RoleType method responses
             RoleType.GetRelationType.Res role_type_get_relation_type_res = 200;
-            RoleType.GetRelationTypes.Res role_type_get_relation_types_res = 201;
-            RoleType.GetPlayers.Res role_type_get_players_res = 202;
 
             // ThingType method responses
             ThingType.SetAbstract.Res thing_type_set_abstract_res = 300;
@@ -357,9 +361,6 @@ message Type {
             ThingType.UnsetOwns.Res thing_type_unset_owns_res = 303;
             ThingType.SetPlays.Res thing_type_set_plays_res = 304;
             ThingType.UnsetPlays.Res thing_type_unset_plays_res = 305;
-            ThingType.GetInstances.Res thing_type_get_instances_res = 306;
-            ThingType.GetOwns.Res thing_type_get_owns_res = 307;
-            ThingType.GetPlays.Res thing_type_get_plays_res = 308;
 
             // EntityType method responses
             EntityType.Create.Res entity_type_create_res = 400;
@@ -369,14 +370,35 @@ message Type {
             RelationType.GetRelatesForRoleLabel.Res relation_type_get_relates_for_role_label_res = 501;
             RelationType.SetRelates.Res relation_type_set_relates_res = 502;
             RelationType.UnsetRelates.Res relation_type_unset_relates_res = 503;
-            RelationType.GetRelates.Res relation_type_get_relates_res = 504;
 
             // AttributeType method responses
             AttributeType.Put.Res attribute_type_put_res = 600;
             AttributeType.Get.Res attribute_type_get_res = 601;
             AttributeType.GetRegex.Res attribute_type_get_regex_res = 602;
             AttributeType.SetRegex.Res attribute_type_set_regex_res = 603;
-            AttributeType.GetOwners.Res attribute_type_get_owners_res = 604;
+        }
+    }
+
+    message ResPart {
+        oneof res {
+            // Type method responses
+            Type.GetSupertypes.ResPart type_get_supertypes_res_part = 100;
+            Type.GetSubtypes.ResPart type_get_subtypes_res_part = 101;
+
+            // RoleType method responses
+            RoleType.GetRelationTypes.ResPart role_type_get_relation_types_res_part = 200;
+            RoleType.GetPlayers.ResPart role_type_get_players_res_part = 201;
+
+            // ThingType method responses
+            ThingType.GetInstances.ResPart thing_type_get_instances_res_part = 300;
+            ThingType.GetOwns.ResPart thing_type_get_owns_res_part = 301;
+            ThingType.GetPlays.ResPart thing_type_get_plays_res_part = 302;
+
+            // RelationType method responses
+            RelationType.GetRelates.ResPart relation_type_get_relates_res_part = 500;
+
+            // AttributeType method responses
+            AttributeType.GetOwners.ResPart attribute_type_get_owners_res_part = 600;
         }
     }
 
@@ -425,14 +447,14 @@ message Type {
 
     message GetSupertypes {
         message Req {}
-        message Res {
-             repeated Type types = 1;
+        message ResPart {
+            repeated Type types = 1;
         }
     }
 
     message GetSubtypes {
         message Req {}
-        message Res {
+        message ResPart {
             repeated Type types = 1;
         }
     }
@@ -451,14 +473,14 @@ message RoleType {
 
     message GetRelationTypes {
         message Req {}
-        message Res {
+        message ResPart {
             repeated Type relation_types = 1;
         }
     }
 
     message GetPlayers {
         message Req {}
-        message Res {
+        message ResPart {
             repeated Type thing_types = 1;
         }
     }
@@ -480,7 +502,7 @@ message ThingType {
 
     message GetInstances {
         message Req {}
-        message Res {
+        message ResPart {
             repeated Thing things = 1;
         }
     }
@@ -492,14 +514,14 @@ message ThingType {
             }
             bool keys_only = 3;
         }
-        message Res {
+        message ResPart {
             repeated Type attribute_types = 1;
         }
     }
 
     message GetPlays {
         message Req {}
-        message Res {
+        message ResPart {
             repeated Type roles = 1;
         }
     }
@@ -565,7 +587,7 @@ message RelationType {
 
     message GetRelates {
         message Req {}
-        message Res {
+        message ResPart {
             repeated Type roles = 1;
         }
     }
@@ -636,7 +658,7 @@ message AttributeType {
         message Req {
             bool only_key = 1;
         }
-        message Res {
+        message ResPart {
             repeated Type owners = 1;
         }
     }
@@ -661,7 +683,7 @@ message AttributeType {
                 ValueType value_type = 1;
             }
         }
-        message Res {
+        message ResPart {
             repeated Type types = 1;
         }
     }
@@ -672,7 +694,7 @@ message AttributeType {
                 ValueType value_type = 1;
             }
         }
-        message Res {
+        message ResPart {
             repeated Thing things = 1;
         }
     }

--- a/protobuf/grakn.proto
+++ b/protobuf/grakn.proto
@@ -40,8 +40,8 @@ service Grakn {
     rpc session_pulse (Session.Pulse.Req) returns (Session.Pulse.Res);
 
     // Opens a bi-directional stream representing a stateful transaction, streaming
-    // requests and responses back-and-forth. The first transaction request must
+    // requests and responses back-and-forth. The first transaction client message must
     // be {Transaction.Open.Req}. Closing the stream closes the transaction.
-    rpc transaction (stream Transaction.Reqs) returns (stream Transaction.Res);
+    rpc transaction (stream Transaction.Client) returns (stream Transaction.Server);
 
 }

--- a/protobuf/logic.proto
+++ b/protobuf/logic.proto
@@ -36,8 +36,11 @@ message LogicManager {
         oneof res {
             GetRule.Res get_rule_res = 1;
             PutRule.Res put_rule_res = 2;
-            GetRules.Res get_rules_res = 3;
         }
+    }
+
+    message ResPart {
+        GetRules.ResPart get_rules_res_part = 1;
     }
 
     message GetRule {
@@ -64,7 +67,7 @@ message LogicManager {
 
     message GetRules {
         message Req {}
-        message Res {
+        message ResPart {
             repeated Rule rules = 1;
         }
     }

--- a/protobuf/query.proto
+++ b/protobuf/query.proto
@@ -25,7 +25,7 @@ import "protobuf/options.proto";
 
 package grakn.protocol;
 
-message Query {
+message QueryManager {
 
     message Req {
         Options options = 1;
@@ -46,13 +46,18 @@ message Query {
         oneof res {
             Define.Res define_res = 100;
             Undefine.Res undefine_res = 101;
-            Match.Res match_res = 102;
-            MatchAggregate.Res match_aggregate_res = 103;
-            MatchGroup.Res match_group_res = 104;
-            MatchGroupAggregate.Res match_group_aggregate_res = 105;
-            Insert.Res insert_res = 106;
-            Delete.Res delete_res = 107;
-            Update.Res update_res = 108;
+            MatchAggregate.Res match_aggregate_res = 102;
+            Delete.Res delete_res = 104;
+        }
+    }
+
+    message ResPart {
+        oneof res {
+            Match.ResPart match_res_part = 100;
+            MatchGroup.ResPart match_group_res_part = 101;
+            MatchGroupAggregate.ResPart match_group_aggregate_res_part = 102;
+            Insert.ResPart insert_res_part = 103;
+            Update.ResPart update_res_part = 104;
         }
     }
 
@@ -60,7 +65,7 @@ message Query {
         message Req {
             string query = 1;
         }
-        message Res {
+        message ResPart {
             repeated ConceptMap answers = 1;
         }
     }
@@ -80,7 +85,7 @@ message Query {
             string query = 1;
         }
 
-        message Res {
+        message ResPart {
             repeated ConceptMapGroup answers = 1;
         }
     }
@@ -90,7 +95,7 @@ message Query {
             string query = 1;
         }
 
-        message Res {
+        message ResPart {
             repeated NumericGroup answers = 1;
         }
     }
@@ -99,7 +104,7 @@ message Query {
         message Req {
             string query = 1;
         }
-        message Res {
+        message ResPart {
             repeated ConceptMap answers = 1;
         }
     }
@@ -115,7 +120,7 @@ message Query {
         message Req {
             string query = 1;
         }
-        message Res {
+        message ResPart {
             repeated ConceptMap answers = 1;
         }
     }

--- a/protobuf/transaction.proto
+++ b/protobuf/transaction.proto
@@ -29,40 +29,57 @@ package grakn.protocol;
 
 message Transaction {
 
-    message Reqs {
-        repeated Transaction.Req transaction_reqs = 1;
+    message Client {
+        repeated Req reqs = 1;
+    }
+
+    message Server {
+        oneof server {
+            Res res = 2;
+            ResPart res_part = 3;
+        }
     }
 
     message Req {
-        string id = 1;
+        string req_id = 1;
         map<string, string> metadata = 2;
         oneof req {
             Open.Req open_req = 3;
             Stream.Req stream_req = 4;
             Commit.Req commit_req = 5;
             Rollback.Req rollback_req = 6;
-            Query.Req query_req = 7;
+            QueryManager.Req query_manager_req = 7;
             ConceptManager.Req concept_manager_req = 8;
-            Thing.Req thing_req = 9;
-            grakn.protocol.Type.Req type_req = 10;
-            LogicManager.Req logic_manager_req = 11;
-            Rule.Req rule_req = 12;
+            LogicManager.Req logic_manager_req = 9;
+            Rule.Req rule_req = 10;
+            grakn.protocol.Type.Req type_req = 11;
+            Thing.Req thing_req = 12;
         }
     }
 
     message Res {
-        string id = 1;
+        string req_id = 1;
         oneof res {
             Open.Res open_res = 2;
-            Stream.Res stream_res = 3;
-            Commit.Res commit_res = 4;
-            Rollback.Res rollback_res = 5;
-            Query.Res query_res = 6;
-            ConceptManager.Res concept_manager_res = 7;
-            Thing.Res thing_res = 8;
+            Commit.Res commit_res = 3;
+            Rollback.Res rollback_res = 4;
+            QueryManager.Res query_manager_res = 5;
+            ConceptManager.Res concept_manager_res = 6;
+            LogicManager.Res logic_manager_res = 7;
+            Rule.Res rule_res = 8;
             grakn.protocol.Type.Res type_res = 9;
-            LogicManager.Res logic_manager_res = 10;
-            Rule.Res rule_res = 11;
+            Thing.Res thing_res = 10;
+        }
+    }
+
+    message ResPart {
+        string req_id = 1;
+        oneof res {
+            Stream.ResPart stream_res_part = 2;
+            QueryManager.ResPart query_manager_res_part = 3;
+            LogicManager.ResPart logic_manager_res_part = 4;
+            grakn.protocol.Type.ResPart type_res_part = 5;
+            Thing.ResPart thing_res_part = 6;
         }
     }
 
@@ -83,7 +100,7 @@ message Transaction {
 
     message Stream {
         message Req {}
-        message Res {
+        message ResPart {
             bool is_done = 1;
         }
     }


### PR DESCRIPTION
## What is the goal of this PR?

The previous definition of Grakn RPC protocol did not differentiate the fact that, for the Transaction Bidirectional Stream, some server responses are complete responses for their associated queries, and others are a partial list of a response which are streamed consecutively to make up a full response incrementally. This makes the protocol not explicitly clear to the developer implementing Grakn clients, without having the internal knowledge of how Grakn server responses are designed. We have now refined the Transaction Bidirectional Stream protocol, to express the server behaviour more explicitly. The Transaction Bidirectional Stream now sends "client" messages and receives back "server" messages. "Server" messages are defined to either be a complete response or a partial response. Additionally, we have refined the variable names for some other message definitions.

This PR is followed by https://github.com/graknlabs/client-java/pull/302 in client-java, and another one in Grakn Core (to be created).