### PR TITLE
Implement Explanations in RPC

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -44,9 +44,6 @@ build:
         git diff --exit-code dependencies/maven/artifacts.snapshot
         bazel run @graknlabs_dependencies//tool/unuseddeps:unused-deps -- list
     deploy-maven-snapshot:
-      filter:
-        owner: graknlabs
-        branch: master
       image: graknlabs-ubuntu-20.04
       dependencies: [build, build-dependency]
       command: |
@@ -54,9 +51,6 @@ build:
         export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //grpc/java:deploy-maven -- snapshot
     deploy-npm-snapshot:
-      filter:
-        owner: graknlabs
-        branch: master
       image: graknlabs-ubuntu-20.04
       command: |
         curl https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
@@ -69,9 +63,6 @@ build:
         bazel run --define version=$(git rev-parse HEAD) //grpc/nodejs:deploy-npm -- snapshot
       dependencies: [build, build-dependency]
     deploy-pip-snapshot:
-      filter:
-        owner: graknlabs
-        branch: master
       image: graknlabs-ubuntu-20.04
       type: foreground
       command: |

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -44,9 +44,9 @@ build:
         git diff --exit-code dependencies/maven/artifacts.snapshot
         bazel run @graknlabs_dependencies//tool/unuseddeps:unused-deps -- list
     deploy-maven-snapshot:
-      filter:
-        owner: graknlabs
-        branch: master
+#       filter:
+#         owner: graknlabs
+#         branch: master
       image: graknlabs-ubuntu-20.04
       dependencies: [build, build-dependency]
       command: |
@@ -54,9 +54,9 @@ build:
         export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //grpc/java:deploy-maven -- snapshot
     deploy-npm-snapshot:
-      filter:
-        owner: graknlabs
-        branch: master
+#       filter
+#         owner: graknlabs
+#         branch: master
       image: graknlabs-ubuntu-20.04
       command: |
         curl https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
@@ -69,9 +69,9 @@ build:
         bazel run --define version=$(git rev-parse HEAD) //grpc/nodejs:deploy-npm -- snapshot
       dependencies: [build, build-dependency]
     deploy-pip-snapshot:
-      filter:
-        owner: graknlabs
-        branch: master
+#       filter:
+#         owner: graknlabs
+#         branch: master
       image: graknlabs-ubuntu-20.04
       type: foreground
       command: |

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -44,6 +44,9 @@ build:
         git diff --exit-code dependencies/maven/artifacts.snapshot
         bazel run @graknlabs_dependencies//tool/unuseddeps:unused-deps -- list
     deploy-maven-snapshot:
+      filter:
+        owner: graknlabs
+        branch: master
       image: graknlabs-ubuntu-20.04
       dependencies: [build, build-dependency]
       command: |
@@ -51,6 +54,9 @@ build:
         export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //grpc/java:deploy-maven -- snapshot
     deploy-npm-snapshot:
+      filter:
+        owner: graknlabs
+        branch: master
       image: graknlabs-ubuntu-20.04
       command: |
         curl https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
@@ -63,6 +69,9 @@ build:
         bazel run --define version=$(git rev-parse HEAD) //grpc/nodejs:deploy-npm -- snapshot
       dependencies: [build, build-dependency]
     deploy-pip-snapshot:
+      filter:
+        owner: graknlabs
+        branch: master
       image: graknlabs-ubuntu-20.04
       type: foreground
       command: |

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -44,9 +44,9 @@ build:
         git diff --exit-code dependencies/maven/artifacts.snapshot
         bazel run @graknlabs_dependencies//tool/unuseddeps:unused-deps -- list
     deploy-maven-snapshot:
-#       filter:
-#         owner: graknlabs
-#         branch: master
+      filter:
+        owner: graknlabs
+        branch: master
       image: graknlabs-ubuntu-20.04
       dependencies: [build, build-dependency]
       command: |
@@ -54,9 +54,9 @@ build:
         export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //grpc/java:deploy-maven -- snapshot
     deploy-npm-snapshot:
-#       filter
-#         owner: graknlabs
-#         branch: master
+      filter:
+        owner: graknlabs
+        branch: master
       image: graknlabs-ubuntu-20.04
       command: |
         curl https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
@@ -69,9 +69,9 @@ build:
         bazel run --define version=$(git rev-parse HEAD) //grpc/nodejs:deploy-npm -- snapshot
       dependencies: [build, build-dependency]
     deploy-pip-snapshot:
-#       filter:
-#         owner: graknlabs
-#         branch: master
+      filter:
+        owner: graknlabs
+        branch: master
       image: graknlabs-ubuntu-20.04
       type: foreground
       command: |

--- a/common/BUILD
+++ b/common/BUILD
@@ -32,7 +32,8 @@ proto_library(
 
 proto_library(
     name = "logic-proto",
-    srcs = ["logic.proto"]
+    srcs = ["logic.proto"],
+    deps = [":answer-proto"]
 )
 
 proto_library(
@@ -45,6 +46,7 @@ proto_library(
     srcs = ["query.proto"],
     deps = [
         ":answer-proto",
+        ":logic-proto",
         ":options-proto",
     ],
 )

--- a/common/answer.proto
+++ b/common/answer.proto
@@ -26,7 +26,24 @@ package grakn.protocol;
 
 message ConceptMap {
     map<string, Concept> map = 1;
-    string pattern = 2;
+    Explainables explainables = 2;
+}
+
+message Explainables {
+    map<string, Explainable> explainable_relations = 1;
+    map<string, Explainable> explainable_attributes = 2;
+    repeated ExplainableOwnership explainable_ownerships = 3;
+}
+
+message ExplainableOwnership {
+    string owner = 1;
+    string attribute = 2;
+    Explainable explainable = 3;
+}
+
+message Explainable {
+    string conjunction = 1;
+    int64 id = 2;
 }
 
 message ConceptMapGroup {

--- a/common/answer.proto
+++ b/common/answer.proto
@@ -30,15 +30,13 @@ message ConceptMap {
 }
 
 message Explainables {
-    map<string, Explainable> explainable_relations = 1;
-    map<string, Explainable> explainable_attributes = 2;
-    repeated ExplainableOwnership explainable_ownerships = 3;
-}
+    map<string, Explainable> relations = 1;
+    map<string, Explainable> attributes = 2;
+    map<string, Owned> ownerships = 3;
 
-message ExplainableOwnership {
-    string owner = 1;
-    string attribute = 2;
-    Explainable explainable = 3;
+    message Owned {
+        map<string, Explainable> owned = 1;
+    }
 }
 
 message Explainable {

--- a/common/logic.proto
+++ b/common/logic.proto
@@ -20,6 +20,9 @@ syntax = "proto3";
 option java_package = "grakn.protocol";
 option java_outer_classname = "LogicProto";
 
+import "common/answer.proto";
+
+
 package grakn.protocol;
 
 message LogicManager {
@@ -104,5 +107,16 @@ message Rule {
             string label = 1;
         }
         message Res {}
+    }
+}
+
+message Explanation {
+    Rule rule = 1;
+    map<string, VarsList> var_mapping = 2; // TODO perhaps this should be a "context" and contain more information about source
+    ConceptMap then_answer = 3;
+    ConceptMap when_answer = 4;
+
+    message VarsList {
+        repeated string vars = 1;
     }
 }

--- a/common/logic.proto
+++ b/common/logic.proto
@@ -112,11 +112,11 @@ message Rule {
 
 message Explanation {
     Rule rule = 1;
-    map<string, VarsList> var_mapping = 2; // TODO perhaps this should be a "context" and contain more information about source
-    ConceptMap then_answer = 3;
-    ConceptMap when_answer = 4;
+    map<string, VarList> var_mapping = 2;
+    ConceptMap condition = 3;
+    ConceptMap conclusion = 4;
 
-    message VarsList {
+    message VarList {
         repeated string vars = 1;
     }
 }

--- a/common/query.proto
+++ b/common/query.proto
@@ -21,6 +21,7 @@ option java_package = "grakn.protocol";
 option java_outer_classname = "QueryProto";
 
 import "common/answer.proto";
+import "common/logic.proto";
 import "common/options.proto";
 
 package grakn.protocol;
@@ -39,6 +40,7 @@ message QueryManager {
             Insert.Req insert_req = 106;
             Delete.Req delete_req = 107;
             Update.Req update_req = 108;
+            Explain.Req explain_req = 109;
         }
     }
 
@@ -58,6 +60,7 @@ message QueryManager {
             MatchGroupAggregate.ResPart match_group_aggregate_res_part = 102;
             Insert.ResPart insert_res_part = 103;
             Update.ResPart update_res_part = 104;
+            Explain.ResPart explain_res_part = 105;
         }
     }
 
@@ -97,6 +100,16 @@ message QueryManager {
 
         message ResPart {
             repeated NumericGroup answers = 1;
+        }
+    }
+
+    message Explain {
+        message Req {
+            int64 explainable_id = 1;
+        }
+
+        message ResPart {
+            repeated Explanation explanations = 1;
         }
     }
 


### PR DESCRIPTION
## What is the goal of this PR?
We add Explanations, and the explain() query endpoint to the protocol. This enables all clients to retrieve all available explanations for a particular explainable concept map.

## What are the changes implemented in this PR?
* Implement `Explainable` and `Explainables` as part of `Answer` protocol
* Implement `Explanation` as part of `Logic` protocol
* Add `Explain.Req` and `Explain.Res` as part of the explain QueryManager endpoing